### PR TITLE
Issue 15

### DIFF
--- a/nam/data.py
+++ b/nam/data.py
@@ -133,7 +133,7 @@ class Dataset(AbstractDataset, InitializableFromConfig):
             if delay > 0:
                 x = x[:-delay]
                 y = y[delay:]
-            else:
+            elif delay < 0:
                 x = x[-delay:]
                 y = y[:delay]
         y = y * y_scale

--- a/tests/test_nam/test_data.py
+++ b/tests/test_nam/test_data.py
@@ -1,0 +1,21 @@
+# File: test_data.py
+# Created Date: Friday May 6th 2022
+# Author: Steven Atkinson (steven@atkinson.mn)
+
+import pytest
+import torch
+
+from nam import data
+
+
+class TestDataset(object):
+    def test_init(self):
+        x, y = torch.randn((2, 7))
+        data.Dataset(x, y, 3, None)
+
+    def test_init_zero_delay(self):
+        """
+        Assert https://github.com/sdatkinson/neural-amp-modeler/issues/15 fixed
+        """
+        x, y = torch.randn((2, 7))
+        data.Dataset(x, y, 3, None, delay=0)


### PR DESCRIPTION
Fix #15 where providing `delay=0` to `nam.data.Dataset`'s initializer cause it to wipe the whole input and output arrays.