### PR TITLE
Improve data validation

### DIFF
--- a/nam/data.py
+++ b/nam/data.py
@@ -152,6 +152,22 @@ def _interpolate_delay(
     )
 
 
+class StartStopError(ValueError):
+    """
+    Exceptions related to invalid start and stop arguments
+    """
+
+    pass
+
+
+class StartError(StartStopError):
+    pass
+
+
+class StopError(StartStopError):
+    pass
+
+
 class Dataset(AbstractDataset, InitializableFromConfig):
     """
     Take a pair of matched audio files and serve input + output pairs.
@@ -350,26 +366,26 @@ class Dataset(AbstractDataset, InitializableFromConfig):
         if start is not None:
             # Start after the files' end?
             if start >= n:
-                raise ValueError(
+                raise StartError(
                     f"Arrays are only {n} samples long, but start was provided as {start}, "
                     "which is beyond the end of the array!"
                 )
             # Start before the files' beginning?
             if start < -n:
-                raise ValueError(
+                raise StartError(
                     f"Arrays are only {n} samples long, but start was provided as {start}, "
                     "which is before the beginning of the array!"
                 )
         if stop is not None:
             # Stop after the files' end?
-            if stop >= n:
-                raise ValueError(
+            if stop > n:
+                raise StopError(
                     f"Arrays are only {n} samples long, but stop was provided as {stop}, "
                     "which is beyond the end of the array!"
                 )
             # Start before the files' beginning?
-            if stop < -n:
-                raise ValueError(
+            if stop <= -n:
+                raise StopError(
                     f"Arrays are only {n} samples long, but stop was provided as {stop}, "
                     "which is before the beginning of the array!"
                 )

--- a/tests/test_nam/test_data.py
+++ b/tests/test_nam/test_data.py
@@ -4,7 +4,7 @@
 
 import math
 from enum import Enum
-from typing import Sequence
+from typing import Tuple
 
 import numpy as np
 import pytest
@@ -106,12 +106,36 @@ class TestDataset(object):
         sample_x2 = d2[0][0]
         assert torch.allclose(sample_x1 * x_scale, sample_x2)
 
+    @pytest.mark.parametrize(
+        "n,start,valid",
+        (
+            (13, None, True),  # No start restrictions; nothing wrong
+            (13, 2, True),  # Starts before the end; fine.
+            (13, 13, False),  # Starts after the end
+            (13, -5, True),  # Starts counting back from the end, fine
+            (13, -14, False),  # Starts before the beginning of the array--invalid
+        ),
+    )
+    def test_validate_start(self, n: int, start: int, valid: bool):
+        def init():
+            data.Dataset(x, y, nx, ny, start=start)
+
+        nx = 1
+        ny = None
+        x, y = self._create_xy(n=n)
+        if valid:
+            init()
+            assert True  # No problem!
+        else:
+            with pytest.raises(ValueError):
+                init()
+
     def _create_xy(
         self,
         n: int = 7,
         method: _XYMethod = _XYMethod.RAND,
         must_be_in_valid_range: bool = True,
-    ) -> Sequence[torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         :return: (n,), (n,)
         """
@@ -119,11 +143,15 @@ class TestDataset(object):
             # note: this isn't "valid" data in the sense that it's beyond (-1, 1).
             # But it is useful for the delay code.
             assert not must_be_in_valid_range
-            return torch.tile(torch.arange(n, dtype=torch.float)[None, :], (2, 1))
+            return tuple(
+                torch.tile(torch.arange(n, dtype=torch.float)[None, :], (2, 1))
+            )
         elif method == _XYMethod.RAND:
-            return 0.99 * (2.0 * torch.rand((2, n)) - 1.0)  # Don't clip
+            return tuple(0.99 * (2.0 * torch.rand((2, n)) - 1.0))  # Don't clip
         elif method == _XYMethod.STEP:
-            return torch.tile((torch.linspace(0.0, 1.0, n) > 0.5)[None, :], (2, 1))
+            return tuple(
+                torch.tile((torch.linspace(0.0, 1.0, n) > 0.5)[None, :], (2, 1))
+            )
 
     def _t_apply_delay_float(
         self, n: int, delay: int, method: data._DelayInterpolationMethod

--- a/tests/test_nam/test_data.py
+++ b/tests/test_nam/test_data.py
@@ -111,8 +111,10 @@ class TestDataset(object):
         (
             (13, None, True),  # No start restrictions; nothing wrong
             (13, 2, True),  # Starts before the end; fine.
+            (13, 12, True),  # Starts w/ one to go--ok
             (13, 13, False),  # Starts after the end
             (13, -5, True),  # Starts counting back from the end, fine
+            (13, -13, True),  # Starts at the beginning of the array--ok
             (13, -14, False),  # Starts before the beginning of the array--invalid
         ),
     )
@@ -127,7 +129,33 @@ class TestDataset(object):
             init()
             assert True  # No problem!
         else:
-            with pytest.raises(ValueError):
+            with pytest.raises(data.StartError):
+                init()
+
+    @pytest.mark.parametrize(
+        "n,stop,valid",
+        (
+            (13, None, True),  # No stop restrictions; nothing wrong
+            (13, 2, True),  # Stops before the end; fine.
+            (13, 13, True),  # Stops at the end--ok
+            (13, 14, False),  # Stops after the end--not ok
+            (13, -5, True),  # Stops counting back from the end, fine
+            (13, -12, True),  # Stops w/ one sample--ok
+            (13, -13, False),  # Stops w/ no samples--not ok
+        ),
+    )
+    def test_validate_stop(self, n: int, stop: int, valid: bool):
+        def init():
+            data.Dataset(x, y, nx, ny, stop=stop)
+
+        nx = 1
+        ny = None
+        x, y = self._create_xy(n=n)
+        if valid:
+            init()
+            assert True  # No problem!
+        else:
+            with pytest.raises(data.StopError):
                 init()
 
     def _create_xy(

--- a/tests/test_nam/test_data.py
+++ b/tests/test_nam/test_data.py
@@ -158,6 +158,28 @@ class TestDataset(object):
             with pytest.raises(data.StopError):
                 init()
 
+    @pytest.mark.parametrize(
+        "lenx,leny,valid",
+        ((3, 3, True), (3, 4, False), (0, 0, False)),  # Lenght mismatch  # Empty!
+    )
+    def test_validate_x_y(self, lenx: int, leny: int, valid: bool):
+        def init():
+            data.Dataset(x, y, nx, ny)
+
+        x, y = self._create_xy()
+        assert len(x) >= lenx, "Invalid test!"
+        assert len(y) >= leny, "Invalid test!"
+        x = x[:lenx]
+        y = y[:leny]
+        nx = 1
+        ny = None
+        if valid:
+            init()
+            assert True  # It worked!
+        else:
+            with pytest.raises(data.XYError):
+                init()
+
     def _create_xy(
         self,
         n: int = 7,


### PR DESCRIPTION
When instantiating `nam.data.Dataset`, validate `x`, `y`, `start`, and `stop` with better error messages.

Resolves #14 and #96 