### PR TITLE
Add architecture information to easy collab

### DIFF
--- a/bin/train/easy_colab.ipynb
+++ b/bin/train/easy_colab.ipynb
@@ -87,8 +87,15 @@
         "\n",
         "🕙Training will go through 100 epochs and take just over 10 minutes.🕙\n",
         "\n",
-        "If you want a better model, you can try training for more epochs--just put in a \n",
-        "different number before hitting go!"
+        "If you want a better model, you can try training for more \"**epochs**\"--just put in a \n",
+        "different number before hitting go!\n",
+        "\n",
+        "\"**architecture**\" selects from several presets for the size of the network. This trades off\n",
+        "modeling quality for how expensive the resulting model will be to run.\n",
+        "\n",
+        "   \"**lite**\" models will run approximately \"**1.5 times**\" faster than \"**standard**\".\n",
+        "\n",
+        "   \"**feather**\" models will run more than **2 times** faster than \"**standard**\".\n"
       ]
     },
     {


### PR DESCRIPTION
This change adds a bit of explanation to the easy collab notebook about what the consequences are of changing the "architecture" parameter.