### PR TITLE
Fix graceful shutdowns for Lightning in Windows

### DIFF
--- a/nam/__init__.py
+++ b/nam/__init__.py
@@ -2,10 +2,24 @@
 # File Created: Tuesday, 2nd February 2021 9:42:50 pm
 # Author: Steven Atkinson (steven@atkinson.mn)
 
+# Hack to recover graceful shutdowns in Windows.
+# This has to happen ASAP
+# See:
+# https://github.com/sdatkinson/neural-amp-modeler/issues/105
+# https://stackoverflow.com/a/44822794
+def _ensure_graceful_shutdowns():
+    import os
+
+    if os.name == "nt":  # OS is Windows
+        os.environ["FOR_DISABLE_CONSOLE_CTRL_HANDLER"] = "1"
+
+
+_ensure_graceful_shutdowns()
+
 from ._version import __version__  # Must be before models or else circular
 
 from . import _core  # noqa F401
 from . import data  # noqa F401
 from . import models  # noqa F401
-from . import train  # noqa F401
 from . import util  # noqa F401
+from . import train  # noqa F401

--- a/nam/train/gui.py
+++ b/nam/train/gui.py
@@ -6,8 +6,23 @@
 GUI for training
 
 Usage:
->>> import nam.train.gui
+>>> from nam.train.gui import run
+>>> run()
 """
+
+# Hack to recover graceful shutdowns in Windows.
+# This has to happen ASAP
+# See:
+# https://github.com/sdatkinson/neural-amp-modeler/issues/105
+# https://stackoverflow.com/a/44822794
+def _ensure_graceful_shutdowns():
+    import os
+
+    if os.name == "nt":  # OS is Windows
+        os.environ["FOR_DISABLE_CONSOLE_CTRL_HANDLER"] = "1"
+
+
+_ensure_graceful_shutdowns()
 
 import tkinter as tk
 from dataclasses import dataclass
@@ -17,8 +32,8 @@ from tkinter import filedialog
 from typing import Callable, Optional, Sequence
 
 try:
-    from .. import __version__
-    from . import core
+    from nam import __version__
+    from nam.train import core
 
     _install_is_valid = True
 except ImportError:
@@ -455,3 +470,7 @@ def run():
         _gui.mainloop()
     else:
         _install_error()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Resolves #105

Adds some hacky changes to `os` so that Ctrl+C causes the desired effect.

Has to be put in a few places, and since it needs to execute really early in the code, it's not really possible to put it in a single place and then re-use the code since that import might happen after the offending code locks in the wrong behavior.

See: https://stackoverflow.com/a/44822794