### PR TITLE
Easy colab typo fix

### DIFF
--- a/bin/train/easy_colab.ipynb
+++ b/bin/train/easy_colab.ipynb
@@ -93,7 +93,7 @@
         "\"**architecture**\" selects from several presets for the size of the network. This trades off\n",
         "modeling quality for how expensive the resulting model will be to run.\n",
         "\n",
-        "   \"**lite**\" models will run approximately \"**1.5 times**\" faster than \"**standard**\".\n",
+        "   \"**lite**\" models will run approximately **1.5 times** faster than \"**standard**\".\n",
         "\n",
         "   \"**feather**\" models will run more than **2 times** faster than \"**standard**\".\n"
       ]


### PR DESCRIPTION
This just removes an unintentional set of quotes from the easy colab notebook.