### PR TITLE
Add Apple Metal support for faster training on M1/M2

### DIFF
--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -234,6 +234,8 @@ def _get_configs(
     }
     if torch.cuda.is_available():
         device_config = {"accelerator": "gpu", "devices": 1}
+    elif torch.backends.mps.is_available():
+        device_config = {"accelerator": "mps", "devices": 1}
     else:
         print("WARNING: No GPU was found. Training will be very slow!")
         device_config = {}


### PR DESCRIPTION
Works on my M1 mac. I'd like to see some testing in the NAM facebook group to verify it still works on non-silicon machines.

I used the CPU environment yml to configure the environment for this.