### PR TITLE
Batched training and silent

### DIFF
--- a/nam/models/_exportable.py
+++ b/nam/models/_exportable.py
@@ -21,7 +21,7 @@ class Exportable(abc.ABC):
     Interface for my custon export format for use in the plugin.
     """
 
-    def export(self, outdir: Path, include_snapshot: bool = False):
+    def export(self, outdir: Path, include_snapshot: bool = False, modelname: str = "model"):
         """
         Interface for exporting.
         You should create at least a `config.json` containing the two fields:
@@ -37,7 +37,7 @@ class Exportable(abc.ABC):
         """
         training = self.training
         self.eval()
-        with open(Path(outdir, "model.nam"), "w") as fp:
+        with open(Path(outdir, modelname + ".nam"), "w") as fp:
             json.dump(
                 {
                     "version": __version__,

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -146,6 +146,7 @@ def _calibrate_delay(
     input_version: Version,
     input_path: str,
     output_path: str,
+    silent: bool=False
 ) -> int:
     if input_version.major == 1:
         calibrate, plot = _calibrate_delay_v1, _plot_delay_v1
@@ -158,7 +159,8 @@ def _calibrate_delay(
     else:
         print("Delay wasn't provided; attempting to calibrate automatically...")
         delay = calibrate(input_path, output_path)
-    plot(delay, input_path, output_path)
+    if not silent:
+        plot(delay, input_path, output_path)
     return delay
 
 
@@ -308,7 +310,12 @@ def _esr(pred: torch.Tensor, target: torch.Tensor) -> float:
 
 
 def _plot(
-    model, ds, window_start: Optional[int] = None, window_end: Optional[int] = None
+        model,
+        ds,
+        window_start: Optional[int] = None,
+        window_end: Optional[int] = None,
+        filepath: Optional[str] = None,
+        silent: bool = False
 ):
     print("Plotting a comparison of your model with the target output...")
     with torch.no_grad():
@@ -339,8 +346,10 @@ def _plot(
     plt.plot(ds.y[window_start:window_end], linestyle="--", label="Target")
     plt.title(f"ESR={esr:.3f}")
     plt.legend()
-    plt.show()
-
+    if filepath is not None:
+        plt.savefig(filepath + ".png")
+    if not silent:
+        plt.show()
 
 def train(
     input_path: str,
@@ -353,6 +362,9 @@ def train(
     lr=0.004,
     lr_decay=0.007,
     seed: Optional[int] = 0,
+    save_plot: bool=False,
+    silent: bool=False,
+    modelname: str="model"
 ):
     if seed is not None:
         torch.manual_seed(seed)
@@ -363,7 +375,7 @@ def train(
     if delay is None:
         if input_version is None:
             input_version = _detect_input_version(input_path)
-        delay = _calibrate_delay(delay, input_version, input_path, output_path)
+        delay = _calibrate_delay(delay, input_version, input_path, output_path, silent=silent)
     else:
         print(f"Delay provided as {delay}; skip calibration")
 
@@ -416,5 +428,7 @@ def train(
         dataset_validation,
         window_start=100_000,  # Start of the plotting window, in samples
         window_end=101_000,  # End of the plotting window, in samples
+        filepath=train_path +'/'+ modelname if save_plot else None,
+        silent=silent
     )
     return model

--- a/nam/train/gui.py
+++ b/nam/train/gui.py
@@ -9,8 +9,6 @@ Usage:
 >>> from nam.train.gui import run
 >>> run()
 """
-import os
-import re
 
 # Hack to recover graceful shutdowns in Windows.
 # This has to happen ASAP
@@ -26,6 +24,7 @@ def _ensure_graceful_shutdowns():
 
 _ensure_graceful_shutdowns()
 
+import re
 import tkinter as tk
 from dataclasses import dataclass
 from enum import Enum
@@ -40,7 +39,6 @@ try:
     _install_is_valid = True
 except ImportError:
     _install_is_valid = False
-
 _BUTTON_WIDTH = 20
 _BUTTON_HEIGHT = 2
 _TEXT_WIDTH = 70
@@ -108,8 +106,10 @@ class _PathButton(object):
             self._label["fg"] = "red"
             self._label["text"] = f"{self._info_str} is not set!"
         else:
+            val = self.val
+            val = val[0] if isinstance(val, tuple) and len(val) == 1 else val
             self._label["fg"] = "black"
-            self._label["text"] = f"{self._info_str} set to {self.val}"
+            self._label["text"] = f"{self._info_str} set to {val}"
 
     def _set_val(self):
         res = {
@@ -163,7 +163,7 @@ class _GUI(object):
         )
 
         # This should probably be to the right somewhere
-        self.getAdditionalOptionsFrames()
+        self._get_additional_options_frame()
 
         # Advanced options for training
         default_architecture = core.Architecture.STANDARD
@@ -198,8 +198,7 @@ class _GUI(object):
 
         self._check_button_states()
 
-    def getAdditionalOptionsFrames(self):
-
+    def _get_additional_options_frame(self):
         # Checkboxes
         self._frame_silent = tk.Frame(self._root)
         self._frame_silent.pack(side=tk.LEFT)
@@ -208,19 +207,20 @@ class _GUI(object):
         self._silent = tk.BooleanVar()
         self._chkbox_silent = tk.Checkbutton(
             self._frame_silent,
-            text='Silent run',
+            text="Silent run",
             variable=self._silent,
-            )
-        self._chkbox_silent.grid(row=1, column=1, sticky='W')
+        )
+        self._chkbox_silent.grid(row=1, column=1, sticky="W")
 
         # Auto save the end plot
         self._save_plot = tk.BooleanVar()
         self._save_plot.set(True)  # default this to true
         self._chkbox_save_plot = tk.Checkbutton(
             self._frame_silent,
-            text='Save plot automatically',
-            variable=self._save_plot, )
-        self._chkbox_save_plot.grid(row=2, column=1, sticky='W')
+            text="Save plot automatically",
+            variable=self._save_plot,
+        )
+        self._chkbox_save_plot.grid(row=2, column=1, sticky="W")
 
     def mainloop(self):
         self._root.mainloop()
@@ -250,9 +250,8 @@ class _GUI(object):
 
         # Run it
         for file in file_list:
-
-            print ("Now training {}".format(file))
-            modelname = re.sub(r"\.wav$", '', file.split("/")[-1])
+            print("Now training {}".format(file))
+            modelname = re.sub(r"\.wav$", "", file.split("/")[-1])
 
             trained_model = core.train(
                 self._path_button_input.val,
@@ -265,8 +264,8 @@ class _GUI(object):
                 lr_decay=lr_decay,
                 seed=seed,
                 silent=self._silent.get(),
-                save_plot=True,
-                modelname=modelname
+                save_plot=self._save_plot.get(),
+                modelname=modelname,
             )
             print("Model training complete!")
             print("Exporting...")


### PR DESCRIPTION
Add batch process functionality:

- simple approach to looping the train function over a number of files
- output audio field type updated to allow multiple file selection or single file (only a single input source can be used)
- 'modelname' added in some places to propagate the name of the final ".nam" file, so that multiple files can be dumped without overwriting each other.  Modelname is just the filename.

Add two new supporting options to GUI interface:

- automatically save plots to png next to model
- 'silent' run mode which will not prompt the user to close the delay window or final plot before finishing

<img width="487" alt="multi1" src="https://user-images.githubusercontent.com/44332958/226157346-c98cfd7e-4e03-4341-8034-27999cebdc22.png">



https://user-images.githubusercontent.com/44332958/226157827-418f7ca3-f68d-4e10-a1c4-82323f168c4b.mp4


