### PR TITLE
Run multi-resolution STFT loss on-device unless it fails

### DIFF
--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -4,6 +4,7 @@
 
 name: nam
 channels:
+  - conda-forge # pytest-mock
   - pytorch
 dependencies:
   - black
@@ -14,6 +15,7 @@ dependencies:
   - numpy
   - pip
   - pytest
+  - pytest-mock
   - pytorch
   - scipy
   - semver

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -4,6 +4,7 @@
 
 name: nam
 channels:
+  - conda-forge # pytest-mock
   - pytorch
   - nvidia
 dependencies:
@@ -15,6 +16,7 @@ dependencies:
   - numpy
   - pip
   - pytest
+  - pytest-mock
   - pytorch
   - pytorch-cuda=11.7
   - scipy

--- a/nam/models/losses.py
+++ b/nam/models/losses.py
@@ -6,7 +6,10 @@
 Loss functions
 """
 
+from typing import Optional
+
 import torch
+from auraloss.freq import MultiResolutionSTFTLoss
 
 
 def esr(preds: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
@@ -31,6 +34,30 @@ def esr(preds: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
         torch.mean(torch.square(preds - targets), dim=1)
         / torch.mean(torch.square(targets), dim=1)
     )
+
+
+def multi_resolution_stft_loss(
+    preds: torch.Tensor,
+    targets: torch.Tensor,
+    loss_func: Optional[MultiResolutionSTFTLoss] = None,
+    device: Optional[torch.device] = None,
+) -> torch.Tensor:
+    """
+    Experimental Multi Resolution Short Time Fourier Transform Loss using auraloss implementation.
+    B: Batch size
+    L: Sequence length
+
+    :param preds: (B,L)
+    :param targets: (B,L)
+    :param loss_func: A pre-initialized instance of the loss function module. Providing
+        this saves time.
+    :param device: If provided, send the preds and targets to the provided device.
+    :return: ()
+    """
+    loss_func = MultiResolutionSTFTLoss() if loss_func is None else loss_func
+    if device is not None:
+        preds, targets = [z.to(device) for z in (preds, targets)]
+    return loss_func(preds, targets)
 
 
 def mse_fft(preds: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ onnxruntime
 pip
 pre-commit
 pytest
+pytest-mock
 pytorch_lightning
 scipy
 sounddevice

--- a/tests/test_nam/test_models/test_base.py
+++ b/tests/test_nam/test_models/test_base.py
@@ -53,7 +53,7 @@ def test_loudness():
 )
 def test_mrstft_loss(batch_size: int, sequence_length: int):
     obj = base.Model(
-        _MockBaseNet(1.0), loss_config=base.LossConfig(mstft_weight=0.0002)
+        _MockBaseNet(1.0), loss_config=base.LossConfig(mrstft_weight=0.0002)
     )
     preds = torch.randn((batch_size, sequence_length))
     targets = torch.randn(preds.shape)


### PR DESCRIPTION
Fallback to `torch.device("cpu")` if calculation fails. If the device was already "cpu", pass out the exception raised.

Resolves #164 