### PR TITLE
Smaller .nam files

### DIFF
--- a/nam/models/_exportable.py
+++ b/nam/models/_exportable.py
@@ -46,7 +46,6 @@ class Exportable(abc.ABC):
                     "weights": self._export_weights().tolist(),
                 },
                 fp,
-                indent=4,
             )
         if include_snapshot:
             x, y = self._export_input_output()


### PR DESCRIPTION
Remove indenting from the .nam files. Saves about 100kB per model (on the "standard" architecture)

Resolves #108