### PR TITLE
Add LSTM to easy colab

### DIFF
--- a/nam/train/colab.py
+++ b/nam/train/colab.py
@@ -62,6 +62,7 @@ def _get_valid_export_directory():
 def run(
     epochs: int = 100,
     delay: Optional[int] = None,
+    model_type: str = "WaveNet",
     architecture: str = "standard",
     lr: float = 0.004,
     lr_decay: float = 0.007,
@@ -87,6 +88,7 @@ def run(
         input_version=input_version,
         epochs=epochs,
         delay=delay,
+        model_type,
         architecture=architecture,
         lr=lr,
         lr_decay=lr_decay,

--- a/nam/train/colab.py
+++ b/nam/train/colab.py
@@ -88,7 +88,7 @@ def run(
         input_version=input_version,
         epochs=epochs,
         delay=delay,
-        model_type,
+        model_type=model_type,
         architecture=architecture,
         lr=lr,
         lr_decay=lr_decay,

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -172,14 +172,14 @@ def _get_lstm_config(architecture):
             "train_truncate": 512,
         },
         Architecture.LITE: {
-            "num_layers": 3,
-            "hidden_size": 24,
+            "num_layers": 2,
+            "hidden_size": 16,
             "train_burn_in": 4096,
             "train_truncate": 512,
         },
         Architecture.FEATHER: {
-            "num_layers": 3,
-            "hidden_size": 24,
+            "num_layers": 1,
+            "hidden_size": 12,
             "train_burn_in": 4096,
             "train_truncate": 512,
         },

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -184,7 +184,6 @@ def _get_lstm_config(architecture):
             "train_truncate": 512,
         },
     }[architecture]
-}
 
 def _get_wavenet_config(architecture):
     return {

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -163,6 +163,28 @@ def _calibrate_delay(
         plot(delay, input_path, output_path)
     return delay
 
+def _get_lstm_config(architecture):
+    return {
+        Architecture.STANDARD: {
+            "num_layers": 3,
+            "hidden_size": 24,
+            "train_burn_in": 4096,
+            "train_truncate": 512,
+        },
+        Architecture.LITE: {
+            "num_layers": 3,
+            "hidden_size": 24,
+            "train_burn_in": 4096,
+            "train_truncate": 512,
+        },
+        Architecture.FEATHER: {
+            "num_layers": 3,
+            "hidden_size": 24,
+            "train_burn_in": 4096,
+            "train_truncate": 512,
+        },
+    }[architecture]
+}
 
 def _get_wavenet_config(architecture):
     return {
@@ -272,14 +294,24 @@ def _get_configs(
     }
     model_config = {
         "net": {
-            "name": "WaveNet",
-            # This should do decently. If you really want a nice model, try turning up
-            # "channels" in the first block and "input_size" in the second from 12 to 16.
-            "config": _get_wavenet_config(architecture),
+            "name": "LSTM",
+            "config": _get_lstm_config(architecture),
         },
-        "loss": {"val_loss": "esr"},
-        "optimizer": {"lr": lr},
-        "lr_scheduler": {"class": "ExponentialLR", "kwargs": {"gamma": 1.0 - lr_decay}},
+        "loss": {
+            "val_loss": "mse",
+            "mask_first": 4096,    
+            "pre_emph_weight": 1.0,
+            "pre_emph_coef": 0.85
+        },
+        "optimizer": {
+        "lr": 0.01
+        },
+        "lr_scheduler": {
+            "class": "ExponentialLR",
+            "kwargs": {
+                "gamma": 0.995
+            }
+        }
     }
     if torch.cuda.is_available():
         device_config = {"accelerator": "gpu", "devices": 1}

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -405,7 +405,7 @@ def train(
     input_version: Optional[Version] = None,
     epochs=100,
     delay=None,
-    model_type: str,
+    model_type: str = "WaveNet",
     architecture: Union[Architecture, str] = Architecture.STANDARD,
     lr=0.004,
     lr_decay=0.007,

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -305,7 +305,7 @@ def _get_configs(
             "optimizer": {"lr": lr},
             "lr_scheduler": {"class": "ExponentialLR", "kwargs": {"gamma": 1.0 - lr_decay}},
         }
-    else
+    else:
         model_config = {
             "net": {
                 "name": "LSTM",


### PR DESCRIPTION
This PR adds support for LSTM training in the easy colab notebook.

@sdatkinson I know you want to keep the easy colab "easy", but I think this is a worthwhile change. It is very handy to be able to use the affordances of the easy colab for LSTM training.

Default behavior is unchanged, and the interface to the user is unchanged. I added a "model_type" parameter (defaults to "WaveNet"). If you set it to "LSTM", it will pick from LSTM architecture presets instead.

I added "standard", "lite", and "feather" configs for LSTM. These are somewhat arbitrary - any feedback is welcome.