### PR TITLE
Move "metadata" before "weights" in exported model

### DIFF
--- a/nam/models/_base.py
+++ b/nam/models/_base.py
@@ -93,7 +93,6 @@ class _Base(nn.Module, InitializableFromConfig, Exportable):
 
     def _get_export_dict(self):
         d = super()._get_export_dict()
-        d["metadata"] = {}
         return d
 
 

--- a/nam/models/_exportable.py
+++ b/nam/models/_exportable.py
@@ -103,5 +103,6 @@ class Exportable(abc.ABC):
             "version": __version__,
             "architecture": self.__class__.__name__,
             "config": self._export_config(),
+            "metadata": {},
             "weights": self._export_weights().tolist(),
         }


### PR DESCRIPTION
Just a little quality-of-life change to move the "metadata" up before "weights" section of the exported .nam file. When manually inspecting the .nam file, it is nice to have all of the non-weight info at the top (previously, the "metadata" section was being written below the "weights").