### PR TITLE
feat: enable batch training of files from a directory.

### DIFF
--- a/nam/train/colab.py
+++ b/nam/train/colab.py
@@ -10,9 +10,10 @@ Hide the mess in Colab to make things look pretty for users.
 from pathlib import Path
 from typing import Optional, Tuple
 
-from ..models.metadata import UserMetadata
-from ._version import Version
-from .core import train
+from nam.models.metadata import UserMetadata
+from nam.train._version import Version
+from nam.train.core import train
+from nam.util import find_files
 
 
 _INPUT_BASENAMES = ((Version(1, 1, 1), "v1_1_1.wav"), (Version(1, 0, 0), "v1.wav"))
@@ -24,7 +25,7 @@ _OUTPUT_BASENAME = "output.wav"
 _TRAIN_PATH = "."
 
 
-def _check_for_files() -> Tuple[Version, str]:
+def _check_for_input_file() -> Tuple[Version, str]:
     print("Checking that we have all of the required audio files...")
     for name in _BUGGY_INPUT_BASENAMES:
         if Path(name).exists():
@@ -43,20 +44,22 @@ def _check_for_files() -> Tuple[Version, str]:
         raise FileNotFoundError(
             f"Didn't find NAM's input audio file. Please upload {_INPUT_BASENAMES[0][1]}"
         )
+    return input_version, input_basename
+
+def _check_for_default_output_file():
     if not Path(_OUTPUT_BASENAME).exists():
         raise FileNotFoundError(
             f"Didn't find your reamped output audio file. Please upload {_OUTPUT_BASENAME}."
-        )
-    return input_version, input_basename
+    )
 
-
-def _get_valid_export_directory():
+def _get_valid_export_directory(reuse=False):
     def get_path(version):
         return Path("exported_models", f"version_{version}")
 
     version = 0
     while get_path(version).exists():
         version += 1
+    version = version if version == 0 or not reuse else version - 1
     return get_path(version)
 
 
@@ -68,6 +71,9 @@ def run(
     lr_decay: float = 0.007,
     seed: Optional[int] = 0,
     user_metadata: Optional[UserMetadata] = None,
+    training_directory: str = None,
+    include_files: str = None,
+    exclude_files: str = None,
 ):
     """
     :param epochs: How amny epochs we'll train for.
@@ -78,14 +84,81 @@ def run(
     :param lr: The initial learning rate
     :param lr_decay: The amount by which the learning rate decays each epoch
     :param seed: RNG seed for reproducibility.
+    :param training_directory: training files directory
+    :param include_files: A regex or sequence of regex patterns separated by comma for files to include in the training.
+                           Defaults to None, which includes all files.
+    :param exclude_files: A regex or sequence of regex patterns separated by comma for files to exclude from the training.
+                           Defaults to None, which excludes no files.
     """
+    save_plot = False
+    silent = False
 
-    input_version, input_basename = _check_for_files()
+    training_list = []
+    # keep current behavior
+    if not training_directory:
+        _check_for_default_output_file()
+        training_list = [_OUTPUT_BASENAME]
+    else:
+        default_exclude =  [input_basename for (_, input_basename) in _INPUT_BASENAMES]
+        exclude_files = default_exclude if exclude_files is None else default_exclude + exclude_files.split(",")
+        training_list = find_files(training_directory, 'wav', include_files, exclude_files)
+        save_plot = True # always save plot when batch training
+        silent = True # always silent when batch training
 
+    if not training_list:
+        raise FileNotFoundError(
+            f"Didn't find any training files in directory '{training_directory}'. Please upload some training files."
+        )
+
+    print(f"The following files are going to be trained: {training_list}")
+    for index, file in enumerate(training_list):
+        print(f"\n* Training file ({index + 1}/{len(training_list)}): {file}")
+        try:
+            _run_single_file(
+                epochs,
+                delay,
+                architecture,
+                lr,
+                lr_decay,
+                seed,
+                user_metadata,
+                file,
+                training_directory,
+                save_plot,
+                silent,
+                index
+            )
+        except Exception as e:
+            print(f"Error training file {file}: {e}")
+            continue
+
+def _get_model_name(file):
+    if file == _OUTPUT_BASENAME:
+        return 'model'
+    return Path(file).stem
+
+def _run_single_file(
+    epochs: int = 100,
+    delay: Optional[int] = None,
+    architecture: str = "standard",
+    lr: float = 0.004,
+    lr_decay: float = 0.007,
+    seed: Optional[int] = 0,
+    user_metadata: Optional[UserMetadata] = None,
+    output_file: str = _OUTPUT_BASENAME,
+    train_path: str = _TRAIN_PATH,
+    save_plot: bool = False,
+    silent: bool = False,
+    index: int = 0,
+):
+
+    input_version, input_basename = _check_for_input_file()
+
+    modelname = _get_model_name(output_file)
     model = train(
         input_basename,
-        _OUTPUT_BASENAME,
-        _TRAIN_PATH,
+        output_file,
+        train_path,
         input_version=input_version,
         epochs=epochs,
         delay=delay,
@@ -93,10 +166,20 @@ def run(
         lr=lr,
         lr_decay=lr_decay,
         seed=seed,
+        save_plot=save_plot,
+        silent=silent,
+        modelname=modelname
     )
 
     print("Exporting your model...")
-    model_export_outdir = _get_valid_export_directory()
-    model_export_outdir.mkdir(parents=True, exist_ok=False)
-    model.net.export(model_export_outdir, user_metadata=user_metadata)
-    print(f"Model exported to {model_export_outdir}. Enjoy!")
+    model_export_outdir = _get_valid_export_directory(reuse=(index > 0))
+    model_export_outdir.mkdir(parents=True, exist_ok=(index > 0))
+    model.net.export(outdir=model_export_outdir, basename=modelname, user_metadata=user_metadata)
+    if save_plot:
+        _move_plot_to_export_dir(model_export_outdir, output_file)
+    print(f"* Model exported to {model_export_outdir}/{modelname}.nam. Enjoy!\n")
+
+def _move_plot_to_export_dir(model_export_outdir, output_file):
+    plot_path = Path(output_file[:output_file.rindex('.')] + ".png")
+    if plot_path.exists():
+        plot_path.rename(Path(model_export_outdir, plot_path.name))

--- a/nam/util.py
+++ b/nam/util.py
@@ -6,9 +6,54 @@
 Helpful utilities
 """
 
+import os
+import re
+from pathlib import Path
+from typing import List, Union, Optional
 from datetime import datetime
 
 
 def timestamp() -> str:
     t = datetime.now()
     return f"{t.year:04d}-{t.month:02d}-{t.day:02d}-{t.hour:02d}-{t.minute:02d}-{t.second:02d}"
+
+def find_files(
+    directory: str,
+    extension: str,
+    include_files: Optional[Union[str, List[str]]] = None,
+    exclude_files: Optional[Union[str, List[str]]] = None) -> List[str]:
+    """
+    Returns a list of file paths in the given directory with the specified extension,
+    and optionally filtered by included and excluded files.
+
+    Args:
+        directory (str): The directory to search for files.
+        extension (str): The extension to search for (without the leading dot).
+        include_files (Union[str, List[str]], optional): A regex or list of regex patterns for files to include
+            in the search. Defaults to None, which includes all files.
+        exclude_files (Union[str, List[str]], optional): A regex or list of regex patterns for files to exclude
+            from the search. Defaults to None, which excludes no files.
+
+    Returns:
+        List[str]: A list of file paths of the matching files.
+
+    Example:
+        To search for all .wav files in a directory, use:
+        >>> find_files('/path/to/directory', 'wav')
+    """
+    include_files = include_files.split(",") if isinstance(include_files, str) else include_files
+    exclude_files = exclude_files.split(",") if isinstance(exclude_files, str) else exclude_files
+    include_files = [] if include_files is None else include_files
+    exclude_files = [] if exclude_files is None else exclude_files
+
+    directory_path = Path(directory)
+    files = []
+    for file_path in directory_path.glob(f'*.{extension}'):
+        if include_files:
+            if not any(re.match(pattern, file_path.name) for pattern in include_files):
+                continue
+        if exclude_files:
+            if any(re.match(pattern, file_path.name) for pattern in exclude_files):
+                continue
+        files.append(str(file_path))
+    return sorted(files)

--- a/tests/test_nam/test_util.py
+++ b/tests/test_nam/test_util.py
@@ -1,0 +1,92 @@
+# File: test_install.py
+# File Created: Saturday, 22nd April 2023 5:49:01 pm
+# Author: Fábio Silva (silva.fabio@gmail.com)
+
+import os
+import shutil
+import pytest
+from tempfile import NamedTemporaryFile
+from nam.util import find_files
+
+
+class TestFindFiles:
+    SEARCH_DIRECTORY = "./tests/fixtures"
+    TMP_FILES_PREFIX = "tmp_files_"
+
+    @classmethod
+    def setup_class(cls):
+        os.makedirs(cls.SEARCH_DIRECTORY, exist_ok=True)
+
+    @classmethod
+    def teardown_class(cls):
+        shutil.rmtree(cls.SEARCH_DIRECTORY)
+
+    def create_tmp_files(self, n_files: int, extension: str, prefix=TMP_FILES_PREFIX, directory=SEARCH_DIRECTORY):
+        tmp_files = []
+        for i in range(1, n_files + 1):
+            tmp_file = NamedTemporaryFile(suffix=f".{extension}", prefix=prefix, dir=directory)
+            tmp_files.append(tmp_file)
+        tmp_files = sorted(tmp_files, key=lambda file: file.name)
+        return tmp_files
+
+    def test_find_files_with_one_file(self):
+        with NamedTemporaryFile(suffix=".wav", prefix=self.TMP_FILES_PREFIX, dir=self.SEARCH_DIRECTORY) as tmp_file:
+            found_files = find_files(self.SEARCH_DIRECTORY, "wav")
+            assert len(found_files) == 1
+            assert os.path.basename(found_files[0]) == os.path.basename(tmp_file.name)
+
+    def test_find_files_with_multiple_files(self):
+        self.create_tmp_files(3, "png")
+        tmp_files = self.create_tmp_files(3, "wav")
+
+        found_files = find_files(self.SEARCH_DIRECTORY, "wav")
+        assert len(found_files) == 3
+        for found_file, tmp_file in zip(found_files, tmp_files):
+            assert os.path.basename(found_file) == os.path.basename(tmp_file.name)
+
+    def test_find_files_with_exclude_files(self):
+        self.create_tmp_files(3, "png")
+        tmp_files = self.create_tmp_files(3, "wav")
+        tmp_files_excluded = self.create_tmp_files(2, "wav")
+        exclude_files=f"{os.path.basename(tmp_files_excluded[0].name)},{os.path.basename(tmp_files_excluded[1].name)}"
+
+        found_files = find_files(self.SEARCH_DIRECTORY, "wav", exclude_files=exclude_files)
+        assert len(found_files) == 3
+        for found_file, tmp_file in zip(found_files, tmp_files):
+            assert os.path.basename(found_file) == os.path.basename(tmp_file.name)
+
+    def test_find_files_with_exclude_files_regex(self):
+        exclude_prefix = "tmp_excluded"
+        self.create_tmp_files(3, "png")
+        tmp_files = self.create_tmp_files(3, "wav")
+        exclude_files = self.create_tmp_files(10, "wav", prefix=exclude_prefix)
+        exclude_files=f"{exclude_prefix}*"
+
+        found_files = find_files(self.SEARCH_DIRECTORY, "wav", exclude_files=exclude_files)
+        assert len(found_files) == 3
+        for found_file, tmp_file in zip(found_files, tmp_files):
+            assert os.path.basename(found_file) == os.path.basename(tmp_file.name)
+
+    def test_find_files_with_include_files(self):
+        self.create_tmp_files(3, "wav")
+        self.create_tmp_files(3, "png")
+        include_file = self.create_tmp_files(1, "wav")[0]
+
+        found_files = find_files(self.SEARCH_DIRECTORY, "wav", include_files=os.path.basename(include_file.name))
+        assert len(found_files) == 1
+        assert os.path.basename(found_files[0]) == os.path.basename(include_file.name)
+
+    def test_find_files_with_include_files_regex(self):
+        included_prefix = "tmp_included"
+        tmp_files = self.create_tmp_files(10, "wav", prefix=included_prefix)
+        self.create_tmp_files(5, "wav")
+        self.create_tmp_files(3, "png")
+        include_files = included_prefix
+
+        found_files = find_files(self.SEARCH_DIRECTORY, "wav", include_files=include_files)
+        assert len(found_files) == 10
+        for found_file, tmp_file in zip(found_files, tmp_files):
+            assert os.path.basename(found_file) == os.path.basename(tmp_file.name)
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
This PR enable batch training of files from a directory running the easy colab.

 - The original behavior has been preserved
 - 3 parameters were added:
    -   training_directory: directory with the files to be trained 
    -  include_files: A regex or sequence of regex patterns separated by comma for files to include in the training.
                           Defaults to None, which includes all files.
     - exclude_files: A regex or sequence of regex patterns separated by comma for files to exclude from the training. 
                           Defaults to None, which excludes no files.
 - Models are exported using the corresponding file name and the associated training plot are also saved in the same exported version folder
 
Usage Examples:

1 - Files in the root directory.  If the files are in the root directory, use `training_directory="."`

![Screenshot 2023-04-22 at 16 49 06](https://user-images.githubusercontent.com/104162642/233813534-a6eb6aa9-1cd2-4fb3-b2be-3b079ced431b.png)

2 - Files in a directory. For instance: `training_directory="training_files"`

![Screenshot 2023-04-22 at 22 26 39](https://user-images.githubusercontent.com/104162642/233814371-33ce6fc0-184d-4504-b6c1-fd1bae27af01.png)

3 - Filtering using include files. For instance:` include_files="Boss" `

![Screenshot 2023-04-22 at 21 58 11](https://user-images.githubusercontent.com/104162642/233813825-28d36259-1014-4e4c-938c-601292ce6a1e.png)

4 - Filtering using include file. For instance:` include_files="Boss,Vox-AC15CH-Crunch-Normal"`

![Screenshot 2023-04-22 at 21 25 13](https://user-images.githubusercontent.com/104162642/233813989-af2cafc3-c4d4-4a83-987d-2a644ebc874d.png)

5 - Filtering using exclude files. For instance: `exclude_files="Boss" `

![Screenshot 2023-04-22 at 22 05 45](https://user-images.githubusercontent.com/104162642/233813917-9f0f4f9d-8889-4d42-b2f4-f7d414f6724f.png)

6 - Filtering using include and exclude files. For instance:  `include_files="Boss,Vox-AC15CH-Crunch-Normal", exclude_files="BossMT2_01" `

![Screenshot 2023-04-22 at 22 12 36](https://user-images.githubusercontent.com/104162642/233814061-cc006e68-759d-45ae-92c6-68bde51d5106.png)

7 - Using a little more advanced regex:

![Screenshot 2023-04-22 at 22 19 00](https://user-images.githubusercontent.com/104162642/233814143-677f2f83-3f7c-4d48-b3d5-68b2df4c9481.png)
