### PR TITLE
Only update metadata flag after batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you don't have a good computer for training ML models, you use Google Colab t
 in the cloud using the pre-made notebooks under `bin\train`.
 
 For the very easiest experience, open 
-[`easy_colab.ipynb` on Google Colab](https://colab.research.google.com/github/sdatkinson/neural-amp-modeler/blob/7c7b46b/bin/train/easy_colab.ipynb) 
+[`easy_colab.ipynb` on Google Colab](https://colab.research.google.com/github/sdatkinson/neural-amp-modeler/blob/b1aa204/bin/train/easy_colab.ipynb) 
 and follow the steps!
 
 For a little more visibility under the hood, you can use [colab.ipynb](https://colab.research.google.com/github/sdatkinson/neural-amp-modeler/blob/main/bin/train/colab.ipynb) instead.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ For playing trained models in real time in a standalone application or plugin, s
 If you don't have a good computer for training ML models, you use Google Colab to train
 in the cloud using the pre-made notebooks under `bin\train`.
 
-For the very easiest experience, simply go to
-[https://colab.research.google.com/github/sdatkinson/neural-amp-modeler/blob/main/bin/train/easy_colab.ipynb](https://colab.research.google.com/github/sdatkinson/neural-amp-modeler/blob/main/bin/train/easy_colab.ipynb) and follow the
-steps!
+For the very easiest experience, open 
+[`easy_colab.ipynb` on Google Colab](https://colab.research.google.com/github/sdatkinson/neural-amp-modeler/blob/7c7b46b/bin/train/easy_colab.ipynb) 
+and follow the steps!
 
 For a little more visibility under the hood, you can use [colab.ipynb](https://colab.research.google.com/github/sdatkinson/neural-amp-modeler/blob/main/bin/train/colab.ipynb) instead.
 

--- a/bin/train/easy_colab.ipynb
+++ b/bin/train/easy_colab.ipynb
@@ -68,8 +68,9 @@
       },
       "outputs": [],
       "source": [
-        "# Hint: change \"v0.5.1\" to \"main\" for the very latest!\n",
-        "!pip install git+https://github.com/sdatkinson/neural-amp-modeler.git@v0.5.1\n",
+        "!pip install neural-amp-modeler\n",
+        "# Hint: use the next line instead for the very latest!\n",
+        "# !pip install git+https://github.com/sdatkinson/neural-amp-modeler.git@main\n",
         "\n",
         "from nam.train.colab import run as _run\n",
         "run = _run\n",

--- a/bin/train/easy_colab.ipynb
+++ b/bin/train/easy_colab.ipynb
@@ -68,7 +68,8 @@
       },
       "outputs": [],
       "source": [
-        "!pip install git+https://github.com/sdatkinson/neural-amp-modeler.git@main\n",
+        "# Hint: change \"v0.5.1\" to \"main\" for the very latest!\n",
+        "!pip install git+https://github.com/sdatkinson/neural-amp-modeler.git@v0.5.1\n",
         "\n",
         "from nam.train.colab import run as _run\n",
         "run = _run\n",

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -421,6 +421,7 @@ def train(
             trainer.checkpoint_callback.best_model_path,
             **Model.parse_config(model_config),
         )
+    model.cpu()
     model.eval()
 
     _plot(

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -389,7 +389,7 @@ def train(
         lr_decay,
     )
 
-    print("Starting training. Let's rock!")
+    print("Starting training. It's time to kick ass and chew bubblegum!")
     model = Model.init_from_config(model_config)
     data_config["common"]["nx"] = model.net.receptive_field
     dataset_train = init_dataset(data_config, Split.TRAIN)

--- a/nam/train/gui.py
+++ b/nam/train/gui.py
@@ -309,10 +309,11 @@ class _GUI(object):
                 if self.user_metadata_flag
                 else UserMetadata(),
             )
-            # Metadata was only valid for 1 run, so make sure it's not used again unless
-            # the user re-visits the window and clicks "ok"
-            self.user_metadata_flag = False
             print("Done!")
+
+        # Metadata was only valid for 1 run, so make sure it's not used again unless
+        # the user re-visits the window and clicks "ok"
+        self.user_metadata_flag = False
 
     def _check_button_states(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requirements = [
 ]
 
 setup(
-    name="nam",
+    name="neural-amp-modeler",
     version=main_ns["__version__"],
     description="Neural amp modeler",
     author="Steven Atkinson",


### PR DESCRIPTION
Only update metadata flag after batch is complete instead of every run so that all files in batch still have metadata

Before:
Every .nam after first file is missing user metadata because user can't open dialog mid-batch.

After:
All files in batch have the same user metadata.  New runs after the batch (or single file) are done still require opening the dialog.
