### PR TITLE
Tweak v2_0_0.wav checks

### DIFF
--- a/nam/train/colab.py
+++ b/nam/train/colab.py
@@ -108,8 +108,11 @@ def run(
         ignore_checks=ignore_checks,
     )
 
-    print("Exporting your model...")
-    model_export_outdir = _get_valid_export_directory()
-    model_export_outdir.mkdir(parents=True, exist_ok=False)
-    model.net.export(model_export_outdir, user_metadata=user_metadata)
-    print(f"Model exported to {model_export_outdir}. Enjoy!")
+    if model is None:
+        print("No model returned; skip exporting!")
+    else:
+        print("Exporting your model...")
+        model_export_outdir = _get_valid_export_directory()
+        model_export_outdir.mkdir(parents=True, exist_ok=False)
+        model.net.export(model_export_outdir, user_metadata=user_metadata)
+        print(f"Model exported to {model_export_outdir}. Enjoy!")

--- a/nam/train/colab.py
+++ b/nam/train/colab.py
@@ -75,6 +75,7 @@ def run(
     lr_decay: float = 0.007,
     seed: Optional[int] = 0,
     user_metadata: Optional[UserMetadata] = None,
+    ignore_checks: bool = False,
 ):
     """
     :param epochs: How amny epochs we'll train for.
@@ -85,6 +86,8 @@ def run(
     :param lr: The initial learning rate
     :param lr_decay: The amount by which the learning rate decays each epoch
     :param seed: RNG seed for reproducibility.
+    :param user_metadata: To include in the exported model
+    :param ignore_checks: Ignores the data quality checks and YOLOs it
     """
 
     input_version, input_basename = _check_for_files()
@@ -101,6 +104,8 @@ def run(
         lr=lr,
         lr_decay=lr_decay,
         seed=seed,
+        local=False,
+        ignore_checks=ignore_checks,
     )
 
     print("Exporting your model...")

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -704,8 +704,13 @@ def train(
                 _nasty_checks_modal()
             else:
                 _print_nasty_checks_warning()
+            if not local:
+                print(
+                    "(To disable this check, run AT YOUR OWN RISK with "
+                    "`ignore_checks=True`.)"
+                )
         else:
-            print("Exiting...")
+            print("Exiting core training...")
             return
 
     data_config, model_config, learning_config = _get_configs(

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -704,12 +704,12 @@ def train(
                 _nasty_checks_modal()
             else:
                 _print_nasty_checks_warning()
-            if not local:
-                print(
-                    "(To disable this check, run AT YOUR OWN RISK with "
-                    "`ignore_checks=True`.)"
-                )
-        else:
+        elif not local:  # And not ignore_checks
+            print(
+                "(To disable this check, run AT YOUR OWN RISK with "
+                "`ignore_checks=True`.)"
+            )
+        if not ignore_checks:
             print("Exiting core training...")
             return
 

--- a/nam/train/gui.py
+++ b/nam/train/gui.py
@@ -312,6 +312,9 @@ class _GUI(object):
                 save_plot=self._save_plot.get(),
                 modelname=basename,
             )
+            if trained_model is None:
+                print("Model training failed! Skip exporting...")
+                continue
             print("Model training complete!")
             print("Exporting...")
             outdir = self._path_button_train_destination.val

--- a/nam/train/gui.py
+++ b/nam/train/gui.py
@@ -60,6 +60,7 @@ _BUTTON_HEIGHT = 2
 _TEXT_WIDTH = 70
 
 _DEFAULT_DELAY = None
+_DEFAULT_IGNORE_CHECKS = False
 
 _ADVANCED_OPTIONS_LEFT_WIDTH = 12
 _ADVANCED_OPTIONS_RIGHT_WIDTH = 12
@@ -71,6 +72,7 @@ class _AdvancedOptions(object):
     architecture: core.Architecture
     num_epochs: int
     delay: Optional[int]
+    ignore_checks: bool
 
 
 class _PathType(Enum):
@@ -203,7 +205,10 @@ class _GUI(object):
         # Advanced options for training
         default_architecture = core.Architecture.STANDARD
         self.advanced_options = _AdvancedOptions(
-            default_architecture, _DEFAULT_NUM_EPOCHS, _DEFAULT_DELAY
+            default_architecture,
+            _DEFAULT_NUM_EPOCHS,
+            _DEFAULT_DELAY,
+            _DEFAULT_IGNORE_CHECKS,
         )
         # Window to edit them:
         self._frame_advanced_options = tk.Frame(self._root)
@@ -233,6 +238,23 @@ class _GUI(object):
 
         self._check_button_states()
 
+    def _check_button_states(self):
+        """
+        Determine if any buttons should be disabled
+        """
+        # Train button is disabled unless all paths are set
+        if any(
+            pb.val is None
+            for pb in (
+                self._path_button_input,
+                self._path_button_output,
+                self._path_button_train_destination,
+            )
+        ):
+            self._button_train["state"] = tk.DISABLED
+            return
+        self._button_train["state"] = tk.NORMAL
+
     def _get_additional_options_frame(self):
         # Checkboxes
         self._frame_silent = tk.Frame(self._root)
@@ -256,6 +278,16 @@ class _GUI(object):
             variable=self._save_plot,
         )
         self._chkbox_save_plot.grid(row=2, column=1, sticky="W")
+
+        # Skip the data quality checks!
+        self._ignore_checks = tk.BooleanVar()
+        self._ignore_checks.set(False)
+        self._chkbox_ignore_checks = tk.Checkbutton(
+            self._frame_silent,
+            text="Ignore data quality checks (DO AT YOUR OWN RISK!)",
+            variable=self._ignore_checks,
+        )
+        self._chkbox_ignore_checks.grid(row=3, column=1, sticky="W")
 
     def mainloop(self):
         self._root.mainloop()
@@ -311,6 +343,8 @@ class _GUI(object):
                 silent=self._silent.get(),
                 save_plot=self._save_plot.get(),
                 modelname=basename,
+                ignore_checks=self._ignore_checks.get(),
+                local=True,
             )
             if trained_model is None:
                 print("Model training failed! Skip exporting...")
@@ -331,23 +365,6 @@ class _GUI(object):
         # Metadata was only valid for 1 run, so make sure it's not used again unless
         # the user re-visits the window and clicks "ok"
         self.user_metadata_flag = False
-
-    def _check_button_states(self):
-        """
-        Determine if any buttons should be disabled
-        """
-        # Train button is diabled unless all paths are set
-        if any(
-            pb.val is None
-            for pb in (
-                self._path_button_input,
-                self._path_button_output,
-                self._path_button_train_destination,
-            )
-        ):
-            self._button_train["state"] = tk.DISABLED
-            return
-        self._button_train["state"] = tk.NORMAL
 
 
 # some typing functions


### PR DESCRIPTION
Improves `v2_0_0.wav`-based training to be a little more permissive. Calibrated thresholds based on toy "noisy" data.

Adds the ability to ignore the checks on GUI & Colab if you think you know better 😉 