### PR TITLE
Restrict Python to 3.10 and earlier

### DIFF
--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -7,6 +7,7 @@ channels:
   - conda-forge # pytest-mock
   - pytorch
 dependencies:
+  - python=3.10.10
   - black
   - flake8
   - h5py

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -7,7 +7,7 @@ channels:
   - conda-forge # pytest-mock
   - pytorch
 dependencies:
-  - python=3.10.10
+  - python<3.11 # onnxruntime
   - black
   - flake8
   - h5py

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -8,6 +8,7 @@ channels:
   - pytorch
   - nvidia
 dependencies:
+  - python=3.10.10
   - black
   - flake8
   - h5py

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -8,7 +8,7 @@ channels:
   - pytorch
   - nvidia
 dependencies:
-  - python=3.10.10
+  - python<3.11 # onnxruntime
   - black
   - flake8
   - h5py


### PR DESCRIPTION
tested with 

* Ubuntu 23.04
* Mac OS 13.3.1 on Apple Silicon M1
