### PR TITLE
Log sample rate in `.nam` files

### DIFF
--- a/bin/train/main.py
+++ b/bin/train/main.py
@@ -181,6 +181,12 @@ def main_inner(
     dataset_validation = init_dataset(data_config, Split.VALIDATION)
     train_dataloader = DataLoader(dataset_train, **learning_config["train_dataloader"])
     val_dataloader = DataLoader(dataset_validation, **learning_config["val_dataloader"])
+    if train_dataloader.dataset.sample_rate != val_dataloader.dataset.sample_rate:
+        raise RuntimeError(
+            "Train and validation data loaders have different data set sample rates: "
+            f"{train_dataloader.dataset.sample_rate}, "
+            f"{val_dataloader.dataset.sample_rate}"
+        )
 
     # ckpt_path = Path(outdir, "checkpoints")
     # ckpt_path.mkdir()
@@ -204,6 +210,7 @@ def main_inner(
         )
     model.cpu()
     model.eval()
+    model.net.sample_rate = train_dataloader.dataset.sample_rate
     if make_plots:
         plot(
             model,

--- a/nam/models/_base.py
+++ b/nam/models/_base.py
@@ -22,6 +22,10 @@ from ._exportable import Exportable
 
 
 class _Base(nn.Module, InitializableFromConfig, Exportable):
+    def __init__(self, sample_rate: Optional[float] = None):
+        super().__init__()
+        self.sample_rate = sample_rate
+
     @abc.abstractproperty
     def pad_start_default(self) -> bool:
         pass
@@ -44,6 +48,17 @@ class _Base(nn.Module, InitializableFromConfig, Exportable):
                 "nam", "models/_resources/loudness_input.wav"
             )
         )
+
+    def _get_export_dict(self):
+        d = super()._get_export_dict()
+        sample_rate_key = "sample_rate"
+        if sample_rate_key in d:
+            raise RuntimeError(
+                "Model wants to put 'sample_rate' into model export dict, but the key "
+                "is already taken!"
+            )
+        d[sample_rate_key] = self.sample_rate
+        return d
 
     def _metadata_loudness(self, gain: float = 1.0, db: bool = True) -> float:
         """

--- a/nam/models/_exportable.py
+++ b/nam/models/_exportable.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 # Model version is independent from package version as of package version 0.5.2 so that
 # the API of the package can iterate at a different pace from that of the model files.
-_MODEL_VERSION = "0.5.1"
+_MODEL_VERSION = "0.5.2"
 
 
 def _cast_enums(d: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/nam/models/conv_net.py
+++ b/nam/models/conv_net.py
@@ -110,9 +110,10 @@ class ConvNet(BaseNet):
         *args,
         train_strategy: TrainStrategy = default_train_strategy,
         ir: Optional[_IR] = None,
+        sample_rate: Optional[float] = None,
         **kwargs,
     ):
-        super().__init__()
+        super().__init__(sample_rate=sample_rate)
         self._net = _conv_net(*args, **kwargs)
         assert train_strategy == TrainStrategy.DILATE, "Stride no longer supported"
         self._train_strategy = train_strategy

--- a/nam/models/linear.py
+++ b/nam/models/linear.py
@@ -18,8 +18,8 @@ from ._base import BaseNet
 
 
 class Linear(BaseNet):
-    def __init__(self, receptive_field: int, bias: bool = False):
-        super().__init__()
+    def __init__(self, receptive_field: int, *args, bias: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
         self._net = nn.Conv1d(1, 1, receptive_field, bias=bias)
 
     @property

--- a/nam/models/recurrent.py
+++ b/nam/models/recurrent.py
@@ -131,6 +131,7 @@ class LSTM(BaseNet):
         train_burn_in: Optional[int] = None,
         train_truncate: Optional[int] = None,
         input_size: int = 1,
+        sample_rate: Optional[float] = None,
         **lstm_kwargs,
     ):
         """
@@ -144,7 +145,7 @@ class LSTM(BaseNet):
         :param input_size: Usually 1 (mono input). A catnet extending this might change
             it and provide the parametric inputs as additional input dimensions.
         """
-        super().__init__()
+        super().__init__(sample_rate=sample_rate)
         if "batch_first" in lstm_kwargs:
             raise ValueError("batch_first cannot be set.")
         self._input_size = input_size

--- a/nam/models/wavenet.py
+++ b/nam/models/wavenet.py
@@ -339,8 +339,8 @@ class _WaveNet(nn.Module):
 
 
 class WaveNet(BaseNet):
-    def __init__(self, *args, **kwargs):
-        super().__init__()
+    def __init__(self, *args, sample_rate: Optional[float] = None, **kwargs):
+        super().__init__(sample_rate=sample_rate)
         self._net = _WaveNet(*args, **kwargs)
 
     @property

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -882,6 +882,12 @@ def train(
     train_dataloader, val_dataloader = _get_dataloaders(
         data_config, learning_config, model
     )
+    if train_dataloader.dataset.sample_rate != val_dataloader.dataset.sample_rate:
+        raise RuntimeError(
+            "Train and validation data loaders have different data set sample rates: "
+            f"{train_dataloader.dataset.sample_rate}, "
+            f"{val_dataloader.dataset.sample_rate}"
+        )
 
     trainer = pl.Trainer(
         callbacks=[

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -873,6 +873,11 @@ def train(
     )
 
     print("Starting training. It's time to kick ass and chew bubblegum!")
+    # Issue:
+    # * Model needs sample rate from data, but data set needs nx from model.
+    # * Model is re-instantiated after training anyways.
+    # (Hacky) solution: set sample rate in model from dataloader after second
+    # instantiation from final checkpoint.
     model = Model.init_from_config(model_config)
     train_dataloader, val_dataloader = _get_dataloaders(
         data_config, learning_config, model
@@ -904,6 +909,7 @@ def train(
         )
     model.cpu()
     model.eval()
+    model.net.sample_rate = train_dataloader.dataset.sample_rate
 
     def window_kwargs(version: Version):
         if version.major == 1:

--- a/tests/test_nam/test_data.py
+++ b/tests/test_nam/test_data.py
@@ -85,6 +85,14 @@ class TestDataset(object):
         x, y = self._create_xy()
         data.Dataset(x, y, 3, None)
 
+    def test_init_sample_rate(self):
+        x, y = self._create_xy()
+        sample_rate = 48_000.0
+        d = data.Dataset(x, y, 3, None, sample_rate=sample_rate)
+        assert hasattr(d, "sample_rate")
+        assert isinstance(d.sample_rate, float)
+        assert d.sample_rate == sample_rate
+
     def test_init_zero_delay(self):
         """
         Assert https://github.com/sdatkinson/neural-amp-modeler/issues/15 fixed
@@ -285,6 +293,7 @@ class TestWav(object):
         # Check if the two arrays are equal
         assert y == pytest.approx(x, abs=self.tolerance)
 
+
 def test_audio_mismatch_shapes_in_order():
     """
     https://github.com/sdatkinson/neural-amp-modeler/issues/257
@@ -293,12 +302,12 @@ def test_audio_mismatch_shapes_in_order():
     num_channels = 1
 
     x, y = [np.zeros((n, num_channels)) for n in (x_samples, y_samples)]
-    
+
     with TemporaryDirectory() as tmpdir:
         y_path = Path(tmpdir, "y.wav")
         data.np_to_wav(y, y_path)
         f = lambda: data.wav_to_np(y_path, required_shape=x.shape)
-    
+
         with pytest.raises(data.AudioShapeMismatchError) as e:
             f()
 
@@ -309,7 +318,7 @@ def test_audio_mismatch_shapes_in_order():
             # x is loaded first; we expect that y matches.
             assert e.shape_expected == (x_samples, num_channels)
             assert e.shape_actual == (y_samples, num_channels)
-            
+
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Resolves #281.

Models' export file now remembers what sample rate they were meant to be used at.