### PR TITLE
GUI: advanced option to enable training-time upsampling so that it is compatible with all training WAVs

### DIFF
--- a/nam/data.py
+++ b/nam/data.py
@@ -301,12 +301,13 @@ class Dataset(AbstractDataset, InitializableFromConfig):
         self._y_path = y_path
         self._validate_inputs_after_processing(x, y, nx, ny)
 
-        if self._resample_rate == 0 or self._resample_rate == self.sample_rate:
+        if self._resample_rate == 0 or self._resample_rate == self._sample_rate:
             self._x = x
             self._y = y
+            self._resample_rate = self._sample_rate  # in case it was 0
         else:
             # Upsample x and y - changed for resampling, e.g. from 48kHz to 96kHz during training
-            print("Resampling for training, original rate: ",self._sample_rate," new rate: ",self._resample_rate)
+            print("Resampling for training, original rate: ", self._sample_rate," new rate: ", self._resample_rate)
             self._x = self._upsample(x, original_rate=self._sample_rate, new_rate=self._resample_rate)
             self._y = self._upsample(y, original_rate=self._sample_rate, new_rate=self._resample_rate)
             self._sample_rate = self._resample_rate

--- a/nam/data.py
+++ b/nam/data.py
@@ -22,7 +22,6 @@ from ._core import InitializableFromConfig
 
 # for upsampling
 import scipy
-import scipy.interpolate
 
 logger = logging.getLogger(__name__)
 
@@ -307,40 +306,23 @@ class Dataset(AbstractDataset, InitializableFromConfig):
             self._y = y
             self._resample_rate = self._sample_rate  # in case it was 0
         else:
-            # Calculate the upsampling factor
-            upsample_factor = self._resample_rate // self._sample_rate
-            if upsample_factor * self._sample_rate == self._resample_rate:
-                print("Resampling for training, original rate: ", self._sample_rate, " new rate: ", self._resample_rate)
-                self._x = self._upsample(x, upsample_factor)
-                self._y = self._upsample(y, upsample_factor)
-                self._sample_rate = self._resample_rate
-            else:
-                raise ValueError("Resample rate must be an integer multiple of the original sample rate.")
+            # Upsample x and y - changed for resampling, e.g. from 48kHz to 96kHz during training
+            print("Resampling for training, original rate: ", self._sample_rate," new rate: ", self._resample_rate)
+            self._x = self._upsample(x, original_rate=self._sample_rate, new_rate=self._resample_rate)
+            self._y = self._upsample(y, original_rate=self._sample_rate, new_rate=self._resample_rate)
+            self._sample_rate = self._resample_rate
+
         self._nx = nx
         self._ny = ny if ny is not None else len(x) - nx + 1
 
-    def _upsample(self, signal, upsample_factor):
+    def _upsample(self, signal: torch.Tensor, original_rate: int, new_rate: int) -> torch.Tensor:
         """
-        Upsample a signal by a specified integer factor using linear interpolation.
-
-        :param signal: Input signal (1D numpy array or torch Tensor).
-        :param upsample_factor: Integer factor to upsample by (e.g., 2, 4).
-        :return: Upsampled signal.
+        Upsample a signal using scipy's resample function.
         """
-
-        # Ensure signal is a numpy array for interpolation
-        if isinstance(signal, torch.Tensor):
-            signal = signal.numpy()
-
-        original_indices = np.arange(len(signal))
-        new_length = len(signal) * upsample_factor
-        new_indices = np.linspace(0, len(signal) - 1, new_length)
-
-        # Linear interpolation
-        interp_func = scipy.interpolate.interp1d(original_indices, signal, kind='linear')
-        upsampled_signal = interp_func(new_indices)
-
-        return torch.Tensor(upsampled_signal)
+        num_samples = int(len(signal) * new_rate / original_rate)
+        signal_np = signal.detach().cpu().numpy()
+        upsampled_signal_np = scipy.signal.resample(signal_np, num_samples)
+        return torch.Tensor(upsampled_signal_np)
 
     def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
         """

--- a/nam/data.py
+++ b/nam/data.py
@@ -301,7 +301,7 @@ class Dataset(AbstractDataset, InitializableFromConfig):
         self._y_path = y_path
         self._validate_inputs_after_processing(x, y, nx, ny)
 
-        if self._resample_rate == 0 or self._resample_rate == self._sample_rate:
+        if self._resample_rate == 0 or self._resample_rate is None or self._resample_rate == self._sample_rate:
             self._x = x
             self._y = y
             self._resample_rate = self._sample_rate  # in case it was 0
@@ -378,6 +378,9 @@ class Dataset(AbstractDataset, InitializableFromConfig):
             config["x_path"], info=True, rate=config.get("rate")
         )
         rate = x_wavinfo.rate
+        resample_rate = None
+        if 'resample_rate' in config:
+            resample_rate = config['resample_rate']
         try:
             y = wav_to_tensor(
                 config["y_path"],
@@ -430,7 +433,7 @@ class Dataset(AbstractDataset, InitializableFromConfig):
             "x_path": config["x_path"],
             "y_path": config["y_path"],
             "sample_rate": rate,
-            "resample_rate": config["resample_rate"],
+            "resample_rate": resample_rate,
             "require_input_pre_silence": config.get(
                 "require_input_pre_silence", _DEFAULT_REQUIRE_INPUT_PRE_SILENCE
             ),

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -801,6 +801,7 @@ def _get_configs(
     lr_decay: float,
     batch_size: int,
     fit_cab: bool,
+    resample_rate: int = 0
 ):
     def get_kwargs(data_info: _DataInfo):
         if data_info.major_version == 1:
@@ -827,8 +828,8 @@ def _get_configs(
     ]
     train_kwargs, validation_kwargs = get_kwargs(data_info)
     data_config = {
-        "train": {"ny": ny, **train_kwargs},
-        "validation": {"ny": None, **validation_kwargs},
+        "train": {"ny": ny, "resample_rate": resample_rate, **train_kwargs},
+        "validation": {"ny": None, "resample_rate": resample_rate, **validation_kwargs},
         "common": {
             "x_path": input_path,
             "y_path": output_path,
@@ -885,14 +886,15 @@ def _get_configs(
             "drop_last": True,
             "num_workers": 0,
         },
-        "val_dataloader": {},
+        "val_dataloader": {
+        },
         "trainer": {"max_epochs": epochs, **device_config},
     }
     return data_config, model_config, learning_config
 
 
 def _get_dataloaders(
-    data_config: Dict, learning_config: Dict, model: Model
+    data_config: Dict, learning_config: Dict, model: Model, resample_rate: int = 0
 ) -> Tuple[DataLoader, DataLoader]:
     data_config, learning_config = [deepcopy(c) for c in (data_config, learning_config)]
     data_config["common"]["nx"] = model.net.receptive_field
@@ -1015,6 +1017,7 @@ def train(
     ignore_checks: bool = False,
     local: bool = False,
     fit_cab: bool = False,
+    resample_rate: int = 0, # 0 means no resample
 ) -> Optional[Model]:
     if seed is not None:
         torch.manual_seed(seed)
@@ -1060,6 +1063,7 @@ def train(
         lr_decay,
         batch_size,
         fit_cab,
+        resample_rate=resample_rate
     )
 
     print("Starting training. It's time to kick ass and chew bubblegum!")

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -801,7 +801,7 @@ def _get_configs(
     lr_decay: float,
     batch_size: int,
     fit_cab: bool,
-    resample_rate: int = 0
+    resample_rate: int = None
 ):
     def get_kwargs(data_info: _DataInfo):
         if data_info.major_version == 1:
@@ -894,7 +894,7 @@ def _get_configs(
 
 
 def _get_dataloaders(
-    data_config: Dict, learning_config: Dict, model: Model, resample_rate: int = 0
+    data_config: Dict, learning_config: Dict, model: Model, resample_rate: int = None
 ) -> Tuple[DataLoader, DataLoader]:
     data_config, learning_config = [deepcopy(c) for c in (data_config, learning_config)]
     data_config["common"]["nx"] = model.net.receptive_field
@@ -1017,7 +1017,7 @@ def train(
     ignore_checks: bool = False,
     local: bool = False,
     fit_cab: bool = False,
-    resample_rate: int = 0, # 0 means no resample
+    resample_rate: int = None,
 ) -> Optional[Model]:
     if seed is not None:
         torch.manual_seed(seed)

--- a/nam/train/gui.py
+++ b/nam/train/gui.py
@@ -62,8 +62,14 @@ _BUTTON_WIDTH = 20
 _BUTTON_HEIGHT = 2
 _TEXT_WIDTH = 70
 
+class _SampleRates(Enum):
+    S48K = "48000"
+    S96K = "96000"
+    S192K = "192000"
+
 _DEFAULT_DELAY = None
 _DEFAULT_IGNORE_CHECKS = False
+_DEFAULT_SAMPLE_RATE = _SampleRates.S48K
 
 _ADVANCED_OPTIONS_LEFT_WIDTH = 12
 _ADVANCED_OPTIONS_RIGHT_WIDTH = 12
@@ -76,12 +82,16 @@ class _AdvancedOptions(object):
     num_epochs: int
     delay: Optional[int]
     ignore_checks: bool
+    sample_rate: _SampleRates
 
 
 class _PathType(Enum):
     FILE = "file"
     DIRECTORY = "directory"
     MULTIFILE = "multifile"
+
+
+
 
 
 class _PathButton(object):
@@ -223,6 +233,7 @@ class _GUI(object):
             _DEFAULT_NUM_EPOCHS,
             _DEFAULT_DELAY,
             _DEFAULT_IGNORE_CHECKS,
+            _DEFAULT_SAMPLE_RATE,
         )
         # Window to edit them:
         self._frame_advanced_options = tk.Frame(self._root)
@@ -337,6 +348,7 @@ class _GUI(object):
         architecture = self.advanced_options.architecture
         delay = self.advanced_options.delay
         file_list = self._path_button_output.val
+        sample_rate = self.advanced_options.sample_rate
 
         # Advanced-er options
         # If you're poking around looking for these, then maybe it's time to learn to
@@ -370,6 +382,7 @@ class _GUI(object):
                 ].variable.get(),
                 local=True,
                 fit_cab=self._checkboxes[_CheckboxKeys.FIT_CAB].variable.get(),
+                resample_rate=int(sample_rate.value)
             )
             if trained_model is None:
                 print("Model training failed! Skip exporting...")
@@ -526,7 +539,6 @@ class _LabeledText(object):
         except tk.TclError:
             return None
 
-
 class _AdvancedOptionsGUI(object):
     """
     A window to hold advanced options (Architecture and number of epochs)
@@ -569,6 +581,17 @@ class _AdvancedOptionsGUI(object):
             type=_int_or_null,
         )
 
+        # Resample: radio buttons
+        self._frame_resample = tk.Frame(self._root)
+        self._frame_resample.pack()
+        self._sample_rate = _LabeledOptionMenu(
+            self._frame_resample,
+            "Resample",
+            _SampleRates,
+            default=self._parent.advanced_options.sample_rate,
+        )
+
+
         # "Ok": apply and destory
         self._frame_ok = tk.Frame(self._root)
         self._frame_ok.pack()
@@ -590,6 +613,7 @@ class _AdvancedOptionsGUI(object):
         Set values to parent and destroy this object
         """
         self._parent.advanced_options.architecture = self._architecture.get()
+        self._parent.advanced_options.sample_rate = self._sample_rate.get()
         epochs = self._epochs.get()
         if epochs is not None:
             self._parent.advanced_options.num_epochs = epochs


### PR DESCRIPTION
Hi, I think I found a good way to allow antialiasing geeks like me to do training-time upsampling. The key idea is to do the upsampling in memory after the wavs have been loaded, validated, and split.

This pull request fixes https://github.com/sdatkinson/neural-amp-modeler/issues/355 .

Please merge to main branch or let me know if something needs to be fixed to be compliant to main. Unit tests pass.

![Screenshot 2024-01-07 at 17 50 05](https://github.com/sdatkinson/neural-amp-modeler/assets/2007263/850db446-e045-455d-b93b-c6deb6a25baa)

Benefits shown in these spectrograms:

![alias](https://github.com/sdatkinson/neural-amp-modeler/assets/2007263/8ae6b2ae-7046-42f2-a7d9-8907bc5dc9d6)

