### PR TITLE
Added a neural network architecture that allows the model to learn long-term dependencies

### DIFF
--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -32,6 +32,7 @@ __all__ = ["train"]
 
 
 class Architecture(Enum):
+    HD = "hd"
     STANDARD = "standard"
     LITE = "lite"
     FEATHER = "feather"
@@ -673,6 +674,33 @@ def _check(
 
 def _get_wavenet_config(architecture):
     return {
+        Architecture.HD: {
+            "layers_configs": [
+                {
+                    "input_size": 1,
+                    "condition_size": 1,
+                    "channels": 16,
+                    "head_size": 8,
+                    "kernel_size": 3,
+                    "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
+                    "activation": "Tanh",
+                    "gated": False,
+                    "head_bias": False,
+                },
+                {
+                    "condition_size": 1,
+                    "input_size": 16,
+                    "channels": 8,
+                    "head_size": 1,
+                    "kernel_size": 3,
+                    "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
+                    "activation": "Tanh",
+                    "gated": False,
+                    "head_bias": True,
+                },
+            ],
+            "head_scale": 0.02,
+        },
         Architecture.STANDARD: {
             "layers_configs": [
                 {


### PR DESCRIPTION
For long-term dependencies and for low-alias 96kHz training it would be great to have an option with slightly larger network and larger receptive field.

Therefore this pull request adds an architecture with "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, **1024**], instead of "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512], as in Architecture.standard. This does not seem to create huge CPU impact at inference time.

This is useful for 96kHz training to get the same effective receptive field in real time compared to the standard architecture in 48kHz. Could be also useful for modeling long-term effects in 48kHz.

This option is automatically reflected by the GUI, while the default is still standard. 

![Screenshot 2024-01-08 at 22 57 31](https://github.com/sdatkinson/neural-amp-modeler/assets/2007263/4d9d0e74-adcd-477c-af73-360e620c1316)



