### PR TITLE
[BUGFIX] Store model's expected sample rate in Lightning checkpoints

### DIFF
--- a/bin/train/main.py
+++ b/bin/train/main.py
@@ -33,6 +33,7 @@ from torch.utils.data import DataLoader
 
 from nam.data import ConcatDataset, ParametricDataset, Split, init_dataset
 from nam.models import Model
+from nam.models._base import BaseNet  # HACK access
 from nam.util import filter_warnings, timestamp
 
 torch.manual_seed(0)
@@ -191,6 +192,7 @@ def main_inner(
             "Train and validation data loaders have different data set sample rates: "
             f"{dataset_train.sample_rate}, {dataset_validation.sample_rate}"
         )
+    model.net.sample_rate = dataset_train.sample_rate
     train_dataloader = DataLoader(dataset_train, **learning_config["train_dataloader"])
     val_dataloader = DataLoader(dataset_validation, **learning_config["val_dataloader"])
 
@@ -215,7 +217,6 @@ def main_inner(
         )
     model.cpu()
     model.eval()
-    model.net.sample_rate = train_dataloader.dataset.sample_rate
     if make_plots:
         plot(
             model,
@@ -226,9 +227,9 @@ def main_inner(
             show=False,
         )
         plot(model, dataset_validation, show=not no_show)
-    # Would like to, but this doesn't work for all cases.
-    # If you're making snapshot models, you may find this convenient to uncomment :)
-    # model.net.export(outdir)
+    # Convenient export for snapshot models:
+    if isinstance(model.net, BaseNet):
+        model.net.export(outdir)
 
 
 if __name__ == "__main__":

--- a/nam/data.py
+++ b/nam/data.py
@@ -753,7 +753,7 @@ _dataset_init_registry = {
 
 
 def register_dataset_initializer(
-    name: str, constructor: Callable[[Any], AbstractDataset]
+    name: str, constructor: Callable[[Any], AbstractDataset], overwrite=False
 ):
     """
     If you have otehr data set types, you can register their initializer by name using
@@ -768,7 +768,7 @@ def register_dataset_initializer(
     :param name: The name that'll be used in the config to ask for the data set type
     :param constructor: The constructor that'll be fed the config.
     """
-    if name in _dataset_init_registry:
+    if name in _dataset_init_registry and not overwrite:
         raise KeyError(
             f"A constructor for dataset name '{name}' is already registered!"
         )

--- a/tests/test_nam/test_models/test_base.py
+++ b/tests/test_nam/test_models/test_base.py
@@ -2,8 +2,13 @@
 # Created Date: Thursday March 16th 2023
 # Author: Steven Atkinson (steven@atkinson.mn)
 
+"""
+Tests for the base network and Lightning module
+"""
+
 import math
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Optional
 
 import numpy as np
@@ -104,6 +109,47 @@ def test_mrstft_loss_cpu_fallback(mocker):
     assert obj._mrstft_device is None
     obj._mrstft_loss(preds, targets)  # Should trigger fallback
     assert obj._mrstft_device == "cpu"
+
+
+class TestSampleRate(object):
+    """
+    Tests for sample_rate interface
+    """
+
+    @pytest.mark.parametrize("expected_sample_rate", (None, 44_100.0, 48_000.0))
+    def test_on_init(self, expected_sample_rate: Optional[float]):
+        model = _MockBaseNet(gain=1.0, sample_rate=expected_sample_rate)
+        self._wrap_assert(model, expected_sample_rate)
+
+    @pytest.mark.parametrize("expected_sample_rate", (None, 44_100.0, 48_000.0))
+    def test_setter(self, expected_sample_rate: Optional[float]):
+        model = _MockBaseNet(gain=1.0)
+        model.sample_rate = expected_sample_rate
+        self._wrap_assert(model, expected_sample_rate)
+
+    @pytest.mark.parametrize("expected_sample_rate", (None, 44_100.0, 48_000.0))
+    def test_state_dict(self, expected_sample_rate: Optional[float]):
+        """
+        Assert that it makes it into the state dict
+
+        https://github.com/sdatkinson/neural-amp-modeler/issues/351
+        """
+        model = _MockBaseNet(gain=1.0, sample_rate=expected_sample_rate)
+        with TemporaryDirectory() as tmpdir:
+            model_path = Path(tmpdir, "model.pt")
+            torch.save(model.state_dict(), model_path)
+            model2 = _MockBaseNet(gain=1.0)
+            model2.load_state_dict(torch.load(model_path))
+        self._wrap_assert(model2, expected_sample_rate)
+
+    @classmethod
+    def _wrap_assert(cls, model: _MockBaseNet, expected: Optional[float]):
+        actual = model.sample_rate
+        if expected is None:
+            assert actual is None
+        else:
+            assert isinstance(actual, float)
+            assert actual == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #351.

Also adds functionality so that sample rate can be stored in plain state dicts via `net.state_dict()` (not used by the main trainer but maybe convenient).

Also makes snapshot models auto-export to `.nam`s at the end of `bin/train/main.py` 🙂 