### PR TITLE
[BUGFIX] Update Pydantic requirements

### DIFF
--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -19,7 +19,7 @@ dependencies:
   - onnxruntime!=1.16.0
   - pip
   - pre-commit
-  - pydantic
+  - pydantic>=2.0.0
   - pytest
   - pytest-mock
   - pytorch

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ onnx
 onnxruntime!=1.16.0  # 1.16.0 has a bug to avoid!
 pip
 pre-commit
-pydantic
+pydantic>=2.0.0
 pytest
 pytest-mock
 pytorch_lightning

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = [
     "numpy",
     "onnx",
     "onnxruntime",
-    "pydantic",
+    "pydantic>=2.0.0",
     "pytorch_lightning",
     "scipy",
     "sounddevice",


### PR DESCRIPTION
I didn't have a change to fully investigate, but this might do it.  Resolves this issue where code is updated to support pydantic 2 but old dependencies are not updated to match

![image](https://github.com/sdatkinson/neural-amp-modeler/assets/44332958/7c08ab46-73be-4b05-8346-106d3c46134f)
