### PR TITLE
[ENHANCEMENT] Put back manual reamp latency compensation in Colab

### DIFF
--- a/bin/train/easy_colab.ipynb
+++ b/bin/train/easy_colab.ipynb
@@ -36,7 +36,7 @@
         "## Step 2: Train!\n",
         "Configure your training run below, then hit the Play button to start training!\n",
         "\n",
-        "🕙NOTE: At default settings, training will take just over 10 minutes.🕙"
+        "🕙NOTE: At default settings, training will take about 10 minutes.🕙"
       ]
     },
     {
@@ -69,6 +69,7 @@
         "#@markdown # Training parameters\n",
         "epochs = 100 #@param {type: \"number\"}\n",
         "architecture = \"standard\"  #@param [\"standard\", \"lite\", \"feather\", \"nano\"] {type: \"string\"}\n",
+        "latency_samples = \"0\"  #@param {type: \"string\"}\n",
         "fit_cab = False  #@param {type: \"boolean\"}\n",
         "ignore_checks = False #@param {type: \"boolean\"}\n",
         "\n",
@@ -78,8 +79,8 @@
         "modeled_by = \"Your name\" #@param {type:\"string\"}\n",
         "gear_make = \"GearCo\" #@param {type:\"string\"}\n",
         "gear_model = \"GearName\" #@param {type:\"string\"}\n",
-        "gear_type = \"pedal\" #@param [\"amp\", \"pedal\", \"pedal_amp\", \"amp_cab\", \"amp_pedal_cab\", \"preamp\", \"studio\"] {type:\"string\"}\n",
-        "tone_type = \"overdrive\" #@param [\"clean\", \"overdrive\", \"crunch\", \"hi_gain\", \"fuzz\"] {type:\"string\"}\n",
+        "gear_type = \"amp\" #@param [\"amp\", \"pedal\", \"pedal_amp\", \"amp_cab\", \"amp_pedal_cab\", \"preamp\", \"studio\"] {type:\"string\"}\n",
+        "tone_type = \"clean\" #@param [\"clean\", \"overdrive\", \"crunch\", \"hi_gain\", \"fuzz\"] {type:\"string\"}\n",
         "\n",
         "def _verbose_enum(E, val):\n",
         "    try:\n",
@@ -89,6 +90,17 @@
         "            str(e)\n",
         "            + \"\\nValid choices are: \"\n",
         "            + \", \".join(list(x.value for x in E))\n",
+        "        )\n",
+        "\n",
+        "def _parse_latency(ls: str):\n",
+        "    if ls.lower() == \"auto\":\n",
+        "        return None\n",
+        "    try:\n",
+        "        return int(ls)\n",
+        "    except ValueError as e:\n",
+        "        raise ValueError(\n",
+        "            f\"Invalid value for latency {ls} was given. Either use 'auto' or provide \"\n",
+        "            f\"the reamp latency, in samples.\\nOriginal error:\\n\\n{e}\"\n",
         "        )\n",
         "\n",
         "user_metadata = None if not use_metadata else UserMetadata(\n",
@@ -107,7 +119,8 @@
         "    architecture=architecture,\n",
         "    fit_cab=fit_cab,  # Change me to True for full-rig modeling!\n",
         "    ignore_checks=ignore_checks,  # Change to True to train anyways with potentially bad data\n",
-        "    user_metadata=user_metadata\n",
+        "    user_metadata=user_metadata,\n",
+        "    delay=_parse_latency(latency_samples)\n",
         ")"
       ]
     },


### PR DESCRIPTION
Auto (default):
![image](https://github.com/sdatkinson/neural-amp-modeler/assets/12240186/31f10e3a-b3af-4417-9fc9-ae3e2039a797)

Set manually (output lags input by 16 samples):
![image](https://github.com/sdatkinson/neural-amp-modeler/assets/12240186/74111220-45cc-40c1-ac99-77dcabb22d02)

DAW over-compensated and the output happens 13 samples _before_ the input:
![image](https://github.com/sdatkinson/neural-amp-modeler/assets/12240186/4af79ac1-f6ad-4caa-ba05-1f6937d9380a)

Resolves #390