### PR TITLE
[chore] Replace deprecated uses of `@abc.abstractproperty`

### DIFF
--- a/nam/models/_base.py
+++ b/nam/models/_base.py
@@ -31,11 +31,13 @@ class _Base(nn.Module, InitializableFromConfig, Exportable):
             "_sample_rate", torch.tensor(0.0 if sample_rate is None else sample_rate)
         )
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def pad_start_default(self) -> bool:
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def receptive_field(self) -> int:
         """
         Receptive field of the model


### PR DESCRIPTION
Closes #407 

This PR removes all uses of the deprecated `@abc.abstractproperty` decorator from the codebase. Replaced with `@property` and `@abc.abstractmethod`. 