### PR TITLE
[ENHANCEMENT] Better latency calculation via averaging

### DIFF
--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -333,7 +333,7 @@ _V4_DATA_INFO = _DataInfo(
 
 _DELAY_CALIBRATION_ABS_THRESHOLD = 0.0003
 _DELAY_CALIBRATION_REL_THRESHOLD = 0.001
-_DELAY_CALIBRATION_SAFETY_FACTOR = 4
+_DELAY_CALIBRATION_SAFETY_FACTOR = 1  # Might be able to make this zero...
 
 
 def _warn_lookaheads(indices: Sequence[int]) -> str:

--- a/tests/test_nam/test_train/test_core.py
+++ b/tests/test_nam/test_train/test_core.py
@@ -161,9 +161,9 @@ class _TCalibrateDelay(object):
         with Capturing() as output:
             self._calibrate_delay(y)
         # `[0]` -- Only look in the first set of blip locations
-        expected_warning = core._warn_lookaheads(
-            list(range(1, len(self._data_info.blip_locations[0]) + 1))
-        )
+        # With #485, we average them all together so there's only one index.
+        # TODO clean this up.
+        expected_warning = core._warn_lookaheads([1])  # "Blip 1"
         assert any(o == expected_warning for o in output), output
 
 


### PR DESCRIPTION
Take the average of the responses to the latency impulses in order to denoise.

This fixes the errors in all 4 problematic files that I've gotten from users.

This could be even more solid if we had more impulses, but the two in the v3 input file is fine.

Resolves #389 