### PR TITLE
removed export_cpp_header in the whole of code

### DIFF
--- a/nam/models/conv_net.py
+++ b/nam/models/conv_net.py
@@ -173,38 +173,6 @@ class ConvNet(_BaseNet):
     def _batchnorm(self) -> bool:
         return _BATCHNORM_NAME in self._net._modules["block_0"]._modules
 
-    def export_cpp_header(self, filename: _Path):
-        with _TemporaryDirectory() as tmpdir:
-            tmpdir = _Path(tmpdir)
-            self.export(_Path(tmpdir))
-            with open(_Path(tmpdir, "config.json"), "r") as fp:
-                _c = _json.load(fp)
-            version = _c["version"]
-            config = _c["config"]
-            with open(filename, "w") as f:
-                f.writelines(
-                    (
-                        "#pragma once\n",
-                        "// Automatically-generated model file\n",
-                        "#include <vector>\n",
-                        f'#define PYTHON_MODEL_VERSION "{version}"\n',
-                        f"const int CHANNELS = {config['channels']};\n",
-                        f"const bool BATCHNORM = {'true' if config['batchnorm'] else 'false'};\n",
-                        "std::vector<int> DILATIONS{"
-                        + ",".join([str(d) for d in config["dilations"]])
-                        + "};\n",
-                        f"const std::string ACTIVATION = \"{config['activation']}\";\n",
-                        "std::vector<float> PARAMS{"
-                        + ",".join(
-                            [
-                                f"{w:.16f}"
-                                for w in _np.load(_Path(tmpdir, "weights.npy"))
-                            ]
-                        )
-                        + "};\n",
-                    )
-                )
-
     def _export_config(self):
         return {
             "channels": self._channels,

--- a/nam/models/exportable.py
+++ b/nam/models/exportable.py
@@ -102,14 +102,6 @@ class Exportable(_abc.ABC):
         # And resume training state
         self.train(training)
 
-    @_abc.abstractmethod
-    def export_cpp_header(self, filename: _Path):
-        """
-        Export a .h file to compile into the plugin with the weights written right out
-        as text
-        """
-        pass
-
     def export_onnx(self, filename: _Path):
         """
         Export model in format for ONNX Runtime

--- a/nam/models/linear.py
+++ b/nam/models/linear.py
@@ -27,9 +27,6 @@ class Linear(_BaseNet):
     def receptive_field(self) -> int:
         return self._net.weight.shape[2]
 
-    def export_cpp_header(self):
-        raise NotImplementedError()
-
     @property
     def _bias(self) -> bool:
         return self._net.bias is not None

--- a/tests/test_nam/test_models/test_base.py
+++ b/tests/test_nam/test_models/test_base.py
@@ -31,8 +31,6 @@ class MockBaseNet(base.BaseNet):
     def receptive_field(self) -> int:
         return 1
 
-    def export_cpp_header(self, filename: Path):
-        pass
 
     def _export_config(self):
         pass

--- a/tests/test_nam/test_models/test_exportable.py
+++ b/tests/test_nam/test_models/test_exportable.py
@@ -200,9 +200,6 @@ class TestExportable(object):
             def forward(self, x: torch.Tensor):
                 return self._scale * x + self._bias
 
-            def export_cpp_header(self, filename: Path):
-                pass
-
             def _export_config(self):
                 return {}
 


### PR DESCRIPTION
This PR removes all occurrences of export_cpp_header across the codebase as it is no longer needed, addressing issue #536. The build and tests have been verified to pass successfully.