### PR TITLE
[BUG] ValueError: Failed to parse version from string '0.1.dev270' 

### DIFF
--- a/nam/train/_version.py
+++ b/nam/train/_version.py
@@ -54,8 +54,6 @@ class Version:
             dev = parts[-1]
         elif 'dev' not in parts[-1]:  # e.g. "0.7.1"
             dev = None
-        #elif len(parts) == 4:  # e.g. "0.7.1.dev7"
-        #    dev = parts[3]
         else:
             raise ValueError(f"Invalid version string {s}")
         try:

--- a/nam/train/_version.py
+++ b/nam/train/_version.py
@@ -50,14 +50,17 @@ class Version:
 
         # Typical
         parts = s.split(".")
-        if len(parts) == 3:  # e.g. "0.7.1"
+        if 'dev' in parts[-1]:  # e.g. "0.7.1"
+            dev = parts[-1]
+        elif 'dev' not in parts[-1]:  # e.g. "0.7.1"
             dev = None
-        elif len(parts) == 4:  # e.g. "0.7.1.dev7"
-            dev = parts[3]
+        #elif len(parts) == 4:  # e.g. "0.7.1.dev7"
+        #    dev = parts[3]
         else:
             raise ValueError(f"Invalid version string {s}")
         try:
-            major, minor, patch = [int(x) for x in parts[:3]]
+            f_dgt = lambda x: ''.join([ch for ch in x if ch.isdigit()])
+            major, minor, patch = [int(f_dgt(x)) for x in parts[:3]]
         except ValueError as e:
             raise ValueError(f"Failed to parse version from string '{s}':\n{e}")
         return cls(major=major, minor=minor, patch=patch, dev=dev)


### PR DESCRIPTION
This PR fixes  issue #541 with version parsing in _version.py, ensuring compatibility with x.x.x and x.x.devx formats. The previous logic failed on two-part versions with dev, causing errors for cases like 0.7.dev7. The update correctly identifies dev versions by checking the last segment and extracting numeric parts while maintaining compatibility. Tested with multiple formats (0.7.1, 0.7.1.dev7, 0.7.dev7), this fix prevents parsing failures and allows future refinements if needed. Please review and provide feedback.