### PR TITLE
[BREAKING] Allow processing when the latency cannot be analyzed but the user latency is present

### DIFF
--- a/nam/train/metadata.py
+++ b/nam/train/metadata.py
@@ -40,13 +40,14 @@ class LatencyCalibrationWarnings(_BaseModel):
 
     matches_lookahead: bool
     disagreement_too_high: bool
+    not_detected: bool
 
 
 class LatencyCalibration(_BaseModel):
     algorithm_version: int
     delays: _List[int]
     safety_factor: int
-    recommended: int
+    recommended: _Optional[int]
     warnings: LatencyCalibrationWarnings
 
 


### PR DESCRIPTION
Currently, when a user explicitly provides a latency value but no corresponding spike is found in the output audio, the system raises a `RuntimeError`. This behavior causes failure in some complex non-linear audio chains that do not produce a clear spike response.

This PR changes the logic so that, whenever the user specifies a latency, the code will fall back to using that value even if no spike is detected.