### PR TITLE
[BUGFIX] Support MRSTFT on Apple Silicon

### DIFF
--- a/nam/models/_from_nam.py
+++ b/nam/models/_from_nam.py
@@ -11,8 +11,13 @@ import torch as _torch
 from .base import BaseNet as _BaseNet
 from .wavenet import WaveNet as _WaveNet
 
+
 def _init_wavenet(config) -> _WaveNet:
-    return _WaveNet(layers_configs=config["layers"], head_config=config["head"], head_scale=config["head_scale"])
+    return _WaveNet(
+        layers_configs=config["layers"],
+        head_config=config["head"],
+        head_scale=config["head_scale"],
+    )
 
 
 def init_from_nam(config) -> _BaseNet:
@@ -24,8 +29,6 @@ def init_from_nam(config) -> _BaseNet:
     ...     config = json.load(fp)
     ...     model = init_from_nam(config)
     """
-    model = {
-        "WaveNet": _init_wavenet
-    }[config["architecture"]](config["config"])
+    model = {"WaveNet": _init_wavenet}[config["architecture"]](config["config"])
     model.import_weights(_torch.Tensor(config["weights"]))
     return model

--- a/nam/models/base.py
+++ b/nam/models/base.py
@@ -58,7 +58,9 @@ class _Base(_nn.Module, _InitializableFromConfig, _Exportable):
     @classmethod
     def _metadata_loudness_x(cls) -> _torch.Tensor:
         return _wav_to_tensor(
-            _importlib.resources.files("nam").joinpath("models/_resources/loudness_input.wav")
+            _importlib.resources.files("nam").joinpath(
+                "models/_resources/loudness_input.wav"
+            )
         )
 
     @property

--- a/nam/models/losses.py
+++ b/nam/models/losses.py
@@ -66,9 +66,26 @@ def multi_resolution_stft_loss(
     :param device: If provided, send the preds and targets to the provided device.
     :return: ()
     """
+
+    def ensure_shape(z: _torch.Tensor) -> _torch.Tensor:
+        """
+        Required for auraloss v0.4
+
+        :param z: (L,) or (B,L)
+        :return: (B,C,L)
+        """
+        if z.ndim == 1:
+            return z[None, None, :]
+        elif z.ndim == 2:
+            return z[:, None, :]
+        else:
+            assert z.ndim == 3, f"Expected 1D or 2D tensor. Got {z.shape}"
+            return z
+
     loss_func = _MultiResolutionSTFTLoss() if loss_func is None else loss_func
     if device is not None:
         preds, targets = [z.to(device) for z in (preds, targets)]
+    preds, targets = [ensure_shape(z) for z in (preds, targets)]
     return loss_func(preds, targets)
 
 

--- a/nam/train/colab.py
+++ b/nam/train/colab.py
@@ -67,13 +67,13 @@ def _check_for_files() -> str:
         print(f"Found {input_basename}, presumed version {input_version}")
     else:
         print(f"Found Proteus input {input_basename}.")
-    
+
     # We found the input. Now check for the output and we'll be good.
     if not _Path(_OUTPUT_BASENAME).exists():
         raise FileNotFoundError(
             f"Didn't find your reamped output audio file. Please upload {_OUTPUT_BASENAME}."
         )
-    
+
     return input_basename
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.8"
 dependencies = [
-    "auraloss==0.4",
+    "auraloss @ git+https://github.com/Atkinson-Advanced-Modeling/auraloss.git@4c45a90",
     "matplotlib",
     "numpy",
     "pydantic>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.8"
 dependencies = [
-    "auraloss==0.3.0",
+    "auraloss==0.4",
     "matplotlib",
     "numpy",
     "pydantic>=2.0.0",

--- a/tests/_skips.py
+++ b/tests/_skips.py
@@ -1,0 +1,13 @@
+"""
+Tools for skipping tests
+"""
+
+import pytest as _pytest
+import torch as _torch
+
+requires_cuda = _pytest.mark.skipif(
+    not _torch.cuda.is_available(), reason="CUDA-specific test"
+)
+requires_mps = _pytest.mark.skipif(
+    not _torch.backends.mps.is_available(), reason="MPS-specific test"
+)

--- a/tests/test_nam/test_models/test_from_nam.py
+++ b/tests/test_nam/test_models/test_from_nam.py
@@ -25,21 +25,10 @@ from nam.models.wavenet import WaveNet as _WaveNet
                         "channels": 16,
                         "head_size": 8,
                         "kernel_size": 3,
-                        "dilations": [
-                            1,
-                            2,
-                            4,
-                            8,
-                            16,
-                            32,
-                            64,
-                            128,
-                            256,
-                            512
-                        ],
+                        "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
                         "activation": "Tanh",
                         "gated": False,
-                        "head_bias": False
+                        "head_bias": False,
                     },
                     {
                         "condition_size": 1,
@@ -47,25 +36,14 @@ from nam.models.wavenet import WaveNet as _WaveNet
                         "channels": 8,
                         "head_size": 1,
                         "kernel_size": 3,
-                        "dilations": [
-                            1,
-                            2,
-                            4,
-                            8,
-                            16,
-                            32,
-                            64,
-                            128,
-                            256,
-                            512
-                        ],
+                        "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
                         "activation": "Tanh",
                         "gated": False,
-                        "head_bias": True
-                    }
+                        "head_bias": True,
+                    },
                 ],
-                "head_scale": 0.02
-            }
+                "head_scale": 0.02,
+            },
         ),
     ),
 )
@@ -88,4 +66,3 @@ def test_load_from_nam(factory, kwargs):
         nam_file_contents.pop("metadata")
         nam_file_contents2.pop("metadata")
         assert nam_file_contents == nam_file_contents2
-    

--- a/tests/test_nam/test_models/test_losses.py
+++ b/tests/test_nam/test_models/test_losses.py
@@ -2,33 +2,35 @@
 # Created Date: Saturday January 28th 2023
 # Author: Steven Atkinson (steven@atkinson.mn)
 
-import pytest
-import torch
-import torch.nn as nn
+import pytest as _pytest
+import torch as _torch
+import torch.nn as _nn
 
-from nam.models import losses
+from nam.models import losses as _losses
+
+from ..._skips import requires_mps as _requires_mps
 
 
-@pytest.mark.parametrize(
+@_pytest.mark.parametrize(
     "x,coef,y_expected",
     (
-        (torch.Tensor([0.0, 1.0, 2.0]), 1.0, torch.Tensor([1.0, 1.0])),
-        (torch.Tensor([0.0, 1.0, 2.0]), 0.5, torch.Tensor([1.0, 1.5])),
+        (_torch.Tensor([0.0, 1.0, 2.0]), 1.0, _torch.Tensor([1.0, 1.0])),
+        (_torch.Tensor([0.0, 1.0, 2.0]), 0.5, _torch.Tensor([1.0, 1.5])),
         (
-            torch.Tensor([[0.0, 1.0, 0.0], [1.0, 1.5, 2.0]]),
+            _torch.Tensor([[0.0, 1.0, 0.0], [1.0, 1.5, 2.0]]),
             0.5,
-            torch.Tensor([[1.0, -0.5], [1.0, 1.25]]),
+            _torch.Tensor([[1.0, -0.5], [1.0, 1.25]]),
         ),
     ),
 )
 def test_apply_pre_emphasis_filter_1d(
-    x: torch.Tensor, coef: float, y_expected: torch.Tensor
+    x: _torch.Tensor, coef: float, y_expected: _torch.Tensor
 ):
-    y_actual = losses.apply_pre_emphasis_filter(x, coef)
-    assert isinstance(y_actual, torch.Tensor)
+    y_actual = _losses.apply_pre_emphasis_filter(x, coef)
+    assert isinstance(y_actual, _torch.Tensor)
     assert y_actual.ndim == y_expected.ndim
     assert y_actual.shape == y_expected.shape
-    assert torch.allclose(y_actual, y_expected)
+    assert _torch.allclose(y_actual, y_expected)
 
 
 def test_esr():
@@ -36,28 +38,37 @@ def test_esr():
     Is the ESR calculation correct?
     """
 
-    class Model(nn.Module):
+    class Model(_nn.Module):
         def forward(self, x):
             return x
 
     batch_size, input_length = 3, 5
     inputs = (
-        torch.linspace(0.1, 1.0, batch_size)[:, None]
-        * torch.full((input_length,), 1.0)[None, :]
+        _torch.linspace(0.1, 1.0, batch_size)[:, None]
+        * _torch.full((input_length,), 1.0)[None, :]
     )  # (batch_size, input_length)
-    target_factor = torch.linspace(0.37, 1.22, batch_size)
+    target_factor = _torch.linspace(0.37, 1.22, batch_size)
     targets = target_factor[:, None] * inputs  # (batch_size, input_length)
     # Do the algebra:
     # y=a*yhat
     # ESR=(y-yhat)^2 / y^2
     # ...
     # =(1/a-1)^2
-    expected_esr = torch.square(1.0 / target_factor - 1.0).mean()
+    expected_esr = _torch.square(1.0 / target_factor - 1.0).mean()
     model = Model()
     preds = model(inputs)
-    actual_esr = losses.esr(preds, targets)
-    assert torch.allclose(actual_esr, expected_esr)
+    actual_esr = _losses.esr(preds, targets)
+    assert _torch.allclose(actual_esr, expected_esr)
+
+
+@_requires_mps
+def test_mrstft_loss_doesnt_fall_back_to_cpu():
+    preds, targets = _torch.randn((2, 2048))
+    # Implicitly assert that this doesn't raise an exception that's usually caught and
+    # fallback
+    # If this raises a NotImplementedError, then that's what we don't want!
+    _losses.multi_resolution_stft_loss(preds, targets, device="mps")
 
 
 if __name__ == "__main__":
-    pytest.main()
+    _pytest.main()


### PR DESCRIPTION
- [x] Add test to assert that Apple Silicon doesn't fall back

Update auraloss to [my fork](https://github.com/Atkinson-Advanced-Modeling/auraloss/commit/4c45a90872ad047973c970bf6c70e7a52260e90c). Might try to PR upstream w/ fixes and get a v0.4.1 published on PyPI :)

This causes our use of the multi-resolution STFT loss, which doesn't use phase (since it's using the default parameters) to not have to call `torch.angle`, which is responsible for the exception that triggers the CPU fallback.

TLDR, Apple Silicon training is now faster!

Resolves #453 

Also contains some formatting fixes