### PR TITLE
[BUGFIX] `nam.model.init_from_nam()`: Support files without `"sample_rate"` key.

### DIFF
--- a/nam/_core.py
+++ b/nam/_core.py
@@ -13,7 +13,7 @@ class InitializableFromConfig(object):
     @classmethod
     def parse_config(cls, config):
         return _deepcopy(config)
-    
+
 
 class WithTeardown(object):
     def teardown(self):

--- a/nam/data.py
+++ b/nam/data.py
@@ -29,7 +29,10 @@ import wavio as _wavio
 from torch.utils.data import Dataset as _Dataset
 from tqdm import tqdm as _tqdm
 
-from ._core import InitializableFromConfig as _InitializableFromConfig, WithTeardown as _WithTeardown
+from ._core import (
+    InitializableFromConfig as _InitializableFromConfig,
+    WithTeardown as _WithTeardown,
+)
 
 logger = _logging.getLogger(__name__)
 

--- a/nam/models/_from_nam.py
+++ b/nam/models/_from_nam.py
@@ -6,6 +6,8 @@
 Initialize models from .nam files
 """
 
+from typing import Optional as _Optional
+
 import torch as _torch
 
 from .base import BaseNet as _BaseNet
@@ -14,15 +16,15 @@ from .recurrent import LSTM as _LSTM
 from .wavenet import WaveNet as _WaveNet
 
 
-def _init_linear(config, sample_rate: float) -> _Linear:
+def _init_linear(config, sample_rate: _Optional[float]) -> _Linear:
     return _Linear(sample_rate=sample_rate, **config)
 
 
-def _init_lstm(config, sample_rate: float) -> _LSTM:
+def _init_lstm(config, sample_rate: _Optional[float]) -> _LSTM:
     return _LSTM(sample_rate=sample_rate, **config)
 
 
-def _init_wavenet(config, sample_rate: float) -> _WaveNet:
+def _init_wavenet(config, sample_rate: _Optional[float]) -> _WaveNet:
     return _WaveNet(
         layers_configs=config["layers"],
         head_config=config["head"],
@@ -40,8 +42,9 @@ def init_from_nam(config) -> _BaseNet:
     ...     config = json.load(fp)
     ...     model = init_from_nam(config)
     """
+    # NB: Some old .nam files don't have a sample_rate. Must .get()
     model = {"Linear": _init_linear, "WaveNet": _init_wavenet, "LSTM": _init_lstm}[
         config["architecture"]
-    ](config=config["config"], sample_rate=config["sample_rate"])
+    ](config=config["config"], sample_rate=config.get("sample_rate", None))
     model.import_weights(_torch.Tensor(config["weights"]))
     return model

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -1682,7 +1682,7 @@ def validate_data(
     for split in _Split:
         try:
             ds = _init_dataset(data_config, split)
-            ds.teardown()    
+            ds.teardown()
             pytorch_data_split_validation_dict[split.value] = (
                 _PyTorchDataSplitValidation(passed=True, msg=None)
             )

--- a/tests/test_nam/test_models/test_from_nam.py
+++ b/tests/test_nam/test_models/test_from_nam.py
@@ -128,7 +128,7 @@ def _compare_lstm_configs(
                     },
                 ],
                 "head_scale": 0.02,
-                "sample_rate": 48000
+                "sample_rate": 48000,
             },
             _default_comparison,
         ),
@@ -139,7 +139,11 @@ def _compare_lstm_configs(
             _compare_lstm_configs,
         ),
         # Linear (an IR)
-        (_Linear, {"receptive_field": 2, "bias": False, "sample_rate": 88200}, _default_comparison),
+        (
+            _Linear,
+            {"receptive_field": 2, "bias": False, "sample_rate": 88200},
+            _default_comparison,
+        ),
     ),
 )
 def test_load_from_nam(


### PR DESCRIPTION
Little bugfix for backward compatibility to some old .nam files.