### PR TITLE
training hpo experiments

### DIFF
--- a/nam/data.py
+++ b/nam/data.py
@@ -353,6 +353,7 @@ class Dataset(AbstractDataset, _InitializableFromConfig):
         require_input_pre_silence: _Optional[
             float
         ] = _DEFAULT_REQUIRE_INPUT_PRE_SILENCE,
+        jitter: bool = False,
     ):
         """
         :param x: The input signal. A 1D array.
@@ -394,6 +395,9 @@ class Dataset(AbstractDataset, _InitializableFromConfig):
             seconds) preceding the start of the data set (`start`) have a silent input.
             If it's not, then raise an exception because the output due to it will leak
             into the data set that we're trying to use. If `None`, don't assert.
+        :param jitter: If True, add a random offset (up to ny//4 samples) to each
+            window's start position during iteration. Prevents overfitting to fixed
+            window boundaries. Should only be enabled for training, not validation.
         """
         self._validate_x_y(x, y)
         self._sample_rate = sample_rate
@@ -425,6 +429,7 @@ class Dataset(AbstractDataset, _InitializableFromConfig):
         self._y = y
         self._nx = nx
         self._ny = ny if ny is not None else len(x) - nx + 1
+        self._jitter = jitter
 
     def __getitem__(self, idx: int) -> _Tuple[_torch.Tensor, _torch.Tensor]:
         """
@@ -435,6 +440,11 @@ class Dataset(AbstractDataset, _InitializableFromConfig):
         if idx >= len(self):
             raise IndexError(f"Attempted to access datum {idx}, but len is {len(self)}")
         i = idx * self._ny
+        if self._jitter:
+            max_jitter = self._ny // 4
+            if max_jitter > 0:
+                max_i = len(self.x) - (self._nx + self._ny - 1)
+                i = min(i + _torch.randint(0, max_jitter, (1,)).item(), max_i)
         j = i + self.y_offset
         return self.x[i : i + self._nx + self._ny - 1], self.y[j : j + self._ny]
 

--- a/nam/models/losses.py
+++ b/nam/models/losses.py
@@ -9,6 +9,7 @@ Loss functions
 from typing import Optional as _Optional
 
 import torch as _torch
+import torch.nn as _nn
 
 from .._dependencies.auraloss.freq import (
     MultiResolutionSTFTLoss as _MultiResolutionSTFTLoss,
@@ -27,12 +28,16 @@ def apply_pre_emphasis_filter(x: _torch.Tensor, coef: float) -> _torch.Tensor:
     return x[..., 1:] - coef * x[..., :-1]
 
 
-def esr(preds: _torch.Tensor, targets: _torch.Tensor) -> _torch.Tensor:
+def esr(
+    preds: _torch.Tensor, targets: _torch.Tensor, eps: float = 0.0
+) -> _torch.Tensor:
     """
     ESR of (a batch of) predictions & targets
 
     :param preds: (N,) or (B,N)
     :param targets: Same as preds
+    :param eps: Added to the denominator ``mean(y^2)`` for numerical stability (0 keeps
+        the classic ratio used for validation metrics).
     :return: ()
     """
     if preds.ndim == 1 and targets.ndim == 1:
@@ -45,10 +50,28 @@ def esr(preds: _torch.Tensor, targets: _torch.Tensor) -> _torch.Tensor:
         raise ValueError(
             f"Expect 2D targets (batch_size, num_samples). Got {targets.shape}"
         )
-    return _torch.mean(
-        _torch.mean(_torch.square(preds - targets), dim=1)
-        / _torch.mean(_torch.square(targets), dim=1)
-    )
+    denom = _torch.mean(_torch.square(targets), dim=1) + eps
+    return _torch.mean(_torch.mean(_torch.square(preds - targets), dim=1) / denom)
+
+
+class ESRLoss(_nn.Module):
+    """
+    ``nn.Module`` wrapper around :func:`esr` for use with ``custom_losses`` in the
+    training config (the generic loader expects a constructible module). Typical use is
+    a small ``weight`` (e.g. ``0.05``) as an auxiliary term alongside MSE and MRSTFT.
+    Name the custom loss key ``"ESR"`` if ``val_loss`` is ``"esr"`` so validation
+    resolves that metric from the loss dict.
+
+    Uses ``mean((p-y)^2) / (mean(y^2) + eps)`` with a small default ``eps`` so quiet
+    targets do not explode the ratio.
+    """
+
+    def __init__(self, eps: float = 1e-8):
+        super().__init__()
+        self._eps = eps
+
+    def forward(self, preds: _torch.Tensor, targets: _torch.Tensor) -> _torch.Tensor:
+        return esr(preds, targets, eps=self._eps)
 
 
 def multi_resolution_stft_loss(

--- a/nam/train/ema.py
+++ b/nam/train/ema.py
@@ -1,0 +1,53 @@
+# File: ema.py
+# Optional exponential moving average (EMA) of weights for Lightning training.
+
+"""
+Optional EMA for training via :class:`pytorch_lightning.callbacks.EMAWeightAveraging`.
+
+Enable in the learning config::
+
+    "ema": {
+        "enabled": true,
+        "decay": 0.999
+    }
+
+When enabled, validation metrics and saved checkpoints use the EMA weights (see Lightning
+``WeightAveraging`` / ``EMAWeightAveraging`` docs).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# Constructor kwargs for EMAWeightAveraging (``enabled`` is consumed here).
+_EMA_KEYS = frozenset(
+    {
+        "device",
+        "use_buffers",
+        "decay",
+        "update_every_n_steps",
+        "update_starting_at_step",
+        "update_starting_at_epoch",
+    }
+)
+
+
+def ema_callback_from_learning_config(
+    learning_config: Dict[str, Any],
+) -> Optional[Any]:
+    """
+    :param learning_config: Same dict as ``nam-full`` / ``full.main`` (may include ``ema``).
+    :return: ``EMAWeightAveraging`` instance if ``ema.enabled`` is true, else ``None``.
+    """
+    ema = learning_config.get("ema")
+    if not isinstance(ema, dict) or not ema.get("enabled", False):
+        return None
+    try:
+        from pytorch_lightning.callbacks import EMAWeightAveraging
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "EMA requires pytorch_lightning with EMAWeightAveraging (recent PL 2.x)."
+        ) from e
+
+    kwargs = {k: v for k, v in ema.items() if k in _EMA_KEYS}
+    return EMAWeightAveraging(**kwargs)

--- a/nam/train/full.py
+++ b/nam/train/full.py
@@ -22,6 +22,7 @@ from nam.data import ConcatDataset as _ConcatDataset
 from nam.data import Split as _Split
 from nam.data import init_dataset as _init_dataset
 from nam.train import lightning_module as _lightning_module
+from nam.train.ema import ema_callback_from_learning_config as _ema_callback_from_learning_config
 from nam.util import filter_warnings as _filter_warnings
 
 _torch.manual_seed(0)
@@ -177,8 +178,13 @@ def main(
         dataset_validation, **learning_config["val_dataloader"]
     )
 
+    callbacks = _create_callbacks(learning_config)
+    ema_cb = _ema_callback_from_learning_config(learning_config)
+    if ema_cb is not None:
+        callbacks = [*callbacks, ema_cb]
+
     trainer = _pl.Trainer(
-        callbacks=_create_callbacks(learning_config),
+        callbacks=callbacks,
         default_root_dir=outdir,
         **learning_config["trainer"],
     )

--- a/nam/train/lightning_module.py
+++ b/nam/train/lightning_module.py
@@ -68,7 +68,8 @@ class _CustomLoss(_NamedTuple):
 @_dataclass
 class LossConfig(_InitializableFromConfig):
     """
-    :param mse_weight: Weight for the MSE loss term. If None, MSE is not computed.
+    :param mse_weight: If None, MSE is not computed (programmatic use only; not set from
+        JSON loss config).
     :param mrstft_weight: Multi-resolution short-time Fourier transform loss
         coefficient. None means to skip; 2e-4 works pretty well if one wants to use it.
     :param mask_first: How many of the first samples to ignore when computing the loss.
@@ -225,6 +226,10 @@ class LightningModule(_pl.LightningModule, _InitializableFromConfig):
     @classmethod
     def parse_config(cls, config):
         """
+        Optimizer: use ``{"class": "<Name>", "kwargs": {...}}`` with a class from
+        ``torch.optim`` (e.g. ``Adam``, ``AdamW``). A flat ``{"lr": ...}`` dict
+        is still accepted and uses ``Adam`` for backward compatibility.
+
         e.g.
 
         {
@@ -236,7 +241,8 @@ class LightningModule(_pl.LightningModule, _InitializableFromConfig):
                 "dc_weight": 0.1
             },
             "optimizer": {
-                "lr": 0.0003
+                "class": "AdamW",
+                "kwargs": {"lr": 0.0003}
             },
             "lr_scheduler": {
                 "class": "ReduceLROnPlateau",
@@ -275,7 +281,12 @@ class LightningModule(_pl.LightningModule, _InitializableFromConfig):
         return self._net
 
     def configure_optimizers(self):
-        optimizer = _torch.optim.Adam(self.parameters(), **self._optimizer_config)
+        oc = self._optimizer_config
+        if isinstance(oc, dict) and "class" in oc and "kwargs" in oc:
+            opt_cls = getattr(_torch.optim, oc["class"])
+            optimizer = opt_cls(self.parameters(), **oc["kwargs"])
+        else:
+            optimizer = _torch.optim.Adam(self.parameters(), **oc)
         if self._scheduler_config is None:
             return optimizer
         else:

--- a/tests/test_nam/test_models/test_losses.py
+++ b/tests/test_nam/test_models/test_losses.py
@@ -61,6 +61,16 @@ def test_esr():
     assert _torch.allclose(actual_esr, expected_esr)
 
 
+def test_esr_eps_stabilizes_tiny_target_energy():
+    """Denominator mean(y^2)+eps avoids blow-up when the target is near silent."""
+    preds = _torch.tensor([[1.0, 0.0, 0.0]])
+    targets = _torch.zeros_like(preds)
+    eps = 1e-8
+    expected = _torch.mean(_torch.square(preds - targets)) / eps
+    actual = _losses.esr(preds, targets, eps=eps)
+    assert _torch.allclose(actual, expected)
+
+
 @_requires_mps
 def test_mrstft_loss_doesnt_fall_back_to_cpu():
     preds, targets = _torch.randn((2, 2048))

--- a/tests/test_nam/test_train/test_ema.py
+++ b/tests/test_nam/test_train/test_ema.py
@@ -1,0 +1,42 @@
+"""Optional EMA callback wiring for nam-full."""
+
+import pytorch_lightning as pl
+from pytorch_lightning.callbacks import EMAWeightAveraging
+
+from nam.train.ema import ema_callback_from_learning_config
+
+
+def test_ema_callback_absent_or_disabled_returns_none():
+    assert ema_callback_from_learning_config({}) is None
+    assert ema_callback_from_learning_config({"ema": {"enabled": False}}) is None
+
+
+def test_ema_callback_enabled_returns_averaging_instance():
+    cb = ema_callback_from_learning_config(
+        {"ema": {"enabled": True, "decay": 0.99, "use_buffers": False}}
+    )
+    assert isinstance(cb, EMAWeightAveraging)
+
+
+def test_full_main_callback_list_includes_ema_when_enabled():
+    from nam.train.full import _create_callbacks
+
+    learning_config = {
+        "trainer": {"check_val_every_n_epoch": 1},
+        "ema": {"enabled": True, "decay": 0.999},
+    }
+    callbacks = _create_callbacks(learning_config)
+    ema_cb = ema_callback_from_learning_config(learning_config)
+    assert ema_cb is not None
+    merged = [*callbacks, ema_cb]
+    trainer = pl.Trainer(
+        accelerator="cpu",
+        devices=1,
+        max_epochs=1,
+        limit_train_batches=0,
+        limit_val_batches=0,
+        enable_progress_bar=False,
+        callbacks=merged,
+    )
+    assert trainer is not None
+    assert any(isinstance(c, EMAWeightAveraging) for c in trainer.callbacks)

--- a/tests/test_nam/test_train/test_lightning_module.py
+++ b/tests/test_nam/test_train/test_lightning_module.py
@@ -142,5 +142,26 @@ def test_custom_losses_init():
     assert loss.item() == _torch.nn.MSELoss()(preds, targets)
 
 
+def test_esr_loss_module_via_custom_losses_config():
+    from nam.models.losses import esr as _esr
+
+    cfg = {
+        "custom_losses": {
+            "ESR": {
+                "name": "nam.models.losses.ESRLoss",
+                "kwargs": {},
+                "weight": 0.05,
+            }
+        },
+    }
+    parsed = _lightning_module.LossConfig.parse_config(cfg)
+    assert parsed["custom_losses"]["ESR"].weight == 0.05
+    preds = _torch.randn((3, 64))
+    targets = _torch.randn(preds.shape)
+    v = parsed["custom_losses"]["ESR"].func(preds, targets)
+    assert v.shape == ()
+    assert _torch.allclose(v, _esr(preds, targets, eps=1e-8))
+
+
 if __name__ == "__main__":
     _pytest.main()


### PR DESCRIPTION
## Summary
- **ESR**: `esr(..., eps)` with `mean(y²)+ε`; **`ESRLoss`** for `custom_losses` (validation still uses classic `esr` with `eps=0`).
- **EMA**: optional via `learning.ema` in **`nam-full`** (Lightning `EMAWeightAveraging`).
- **Optimizer**: JSON `{"class", "kwargs"}` (e.g. AdamW) or flat dict → Adam.
- **Data**: optional train **`jitter`** (random window offset up to `ny//4`).
- **Tests** for the above.

## Config (no code changes required)
- **`trainer.gradient_clip_val`** in learning JSON → Lightning `Trainer`.
- **`lr_scheduler`** (e.g. **ReduceLROnPlateau** + `monitor: val_loss`) in model JSON → existing `configure_optimizers` path.

## Notes
I actually found the ESR as aux loss doesn't help but keeping it here we are curious to sweep it. It may be worth trying it as main loss instead. As val loss it does seem to help...

IDK that reduce on plateau makes any sence w/ 350 epochs. maybe `CosineAnnealingWarmRestarts` instead or what we had.

Not sure which of the others are helping, need to do some ablation and sweeps.

## Tried and Failed

tried a warmup wrapper around lr scheduler - seemed to just hurt

## Configs

data.json
```
{
   ....
   "train": {
       ...
       "jitter": true
    }
    ....
}
```

learning.json

```
{
  "train_dataloader": {
    "batch_size": 16,
    "shuffle": true,
    "pin_memory": false,
    "drop_last": true,
    "num_workers": 0
  },
  "val_dataloader": {
    "pin_memory": false
  },
  "trainer": {
    "accelerator": "auto",
    "devices": 1,
    "max_epochs": 350,
    "gradient_clip_val": 1.0
  },
  "trainer_fit_kwargs": {},
  "ema": {
    "enabled": true,
    "decay": 0.999,
    "use_buffers": true
  }
}
```

model.json
```
{
    "net": {
        "name": "WaveNet",
        "config": {
            ...legolas config
        }
    },
    "loss": {
        "val_loss": "esr",
        "mrstft_weight": 0.0005,
        "custom_losses": {
            "ESR": {
                "name": "nam.models.losses.ESRLoss",
                "kwargs": {
                    "eps": 1e-6
                },
                "weight": 0 // zeroed this out and it did better
            }
        }
    },
    "optimizer": {
        "class": "AdamW",
        "kwargs": {
            "lr": 0.004,
            "weight_decay": 3.17e-07
        }
    },
    "lr_scheduler": {
        "class": "ReduceLROnPlateau",
        "kwargs": {
            "factor": 0.6,
            "patience": 10,
            "cooldown": 5,
            "min_lr": 1e-6,
            "threshold": 1e-4,
            "threshold_mode": "rel"
        },
        "monitor": "val_loss"
    }
}
```