### PR TITLE
[FEATURE] Packed WaveNet training

### DIFF
--- a/docs/source/tutorials/main.rst
+++ b/docs/source/tutorials/main.rst
@@ -7,4 +7,5 @@ Tutorials
    colab
    gui
    full
+   packed-training
    calibration

--- a/docs/source/tutorials/packed-training.rst
+++ b/docs/source/tutorials/packed-training.rst
@@ -1,0 +1,184 @@
+Packed training
+===============
+
+Packed training trains several compatible WaveNet submodels inside one larger
+masked WaveNet. Each submodel makes its own prediction for the same target
+audio, and training computes the loss for each prediction against that target
+before summing the losses.
+
+This is different from slimmable WaveNet training. Packed training keeps the
+submodels independent during training by using block-diagonal masked weights.
+The exported ``model.nam`` is also not a packed inference graph: export extracts
+ordinary ``WaveNet`` models and stores them in a ``SlimmableContainer``.
+
+When to use packed training
+---------------------------
+
+Use packed training when you want one ``model.nam`` container with several
+WaveNet sizes, and the submodels share the same temporal architecture but use
+different channel counts. This is useful when training several related WaveNet
+models separately would repeat much of the same work.
+
+Packed training is currently intended for compatible mono WaveNet models. If
+the submodels need different kernels, dilations, activation types, conditioning
+paths, heads, or grouped/FiLM features, train them separately for now.
+
+Configuration
+-------------
+
+Packed training uses the normal full trainer command. Put ``"PackedWaveNet"``
+in the model config and run ``nam-full`` the same way as ordinary full training:
+
+.. code-block:: console
+
+    $ nam-full path/to/data.json path/to/model.json path/to/learning.json path/to/outputs
+
+No extra command-line flag is needed. The trainer chooses
+``PackedLightningModule`` from the model config.
+
+The public example config is
+`nam_full_configs/models/wavenet_packed.json <https://github.com/sdatkinson/neural-amp-modeler/blob/main/nam_full_configs/models/wavenet_packed.json>`_.
+An abbreviated version looks like this:
+
+.. code-block:: json
+
+    {
+      "net": {
+        "name": "PackedWaveNet",
+        "config": {
+          "submodels": [
+            {
+              "name": "small",
+              "config": {
+                "layers_configs": [
+                  {
+                    "input_size": 1,
+                    "condition_size": 1,
+                    "channels": 3,
+                    "head": {"out_channels": 1, "kernel_size": 1, "bias": true},
+                    "kernel_size": 6,
+                    "dilations": [1, 5, 29, 97, 227],
+                    "activation": "LeakyReLU"
+                  }
+                ],
+                "head": null,
+                "head_scale": 0.01
+              }
+            },
+            {
+              "name": "large",
+              "config": {
+                "layers_configs": [
+                  {
+                    "input_size": 1,
+                    "condition_size": 1,
+                    "channels": 8,
+                    "head": {"out_channels": 1, "kernel_size": 1, "bias": true},
+                    "kernel_size": 6,
+                    "dilations": [1, 5, 29, 97, 227],
+                    "activation": "LeakyReLU"
+                  }
+                ],
+                "head": null,
+                "head_scale": 0.01
+              }
+            }
+          ],
+          "export": {
+            "container_max_values": "uniform"
+          }
+        }
+      }
+    }
+
+The ``submodels`` list names each exported model and gives each one an ordinary
+WaveNet ``config``. Channel counts such as ``channels`` may differ between
+submodels. Temporal settings such as ``kernel_size`` and ``dilations`` must
+match.
+
+The optional ``export.container_max_values`` setting controls the
+``max_value`` thresholds written into the exported ``SlimmableContainer``. Use
+``"uniform"`` to spread the thresholds evenly across the submodels, or provide
+a sorted list with one value per submodel. The final threshold is written as
+``1.0``.
+
+Compatibility requirements
+--------------------------
+
+Packed submodels must be structurally compatible:
+
+* The submodels must have the same number of layer arrays.
+* Corresponding layer arrays must have the same number of layers.
+* Corresponding layer arrays must use the same kernel sizes and dilations.
+* Activation configuration must match across corresponding layers.
+* ``head_scale`` must match across submodels.
+* Condition sizes must match, and the current implementation expects mono
+  conditioning audio.
+* Layer-array head settings must line up across arrays. In multi-array models,
+  each array's input and head path must match the previous array's channel and
+  head outputs.
+* Layer-array head kernel sizes and bias flags must match.
+* ``layer_1x1`` and ``head_1x1`` active flags must match.
+
+Channel counts may differ. That is the usual reason to use packed training.
+
+Unsupported combinations
+------------------------
+
+Packed training currently does not support:
+
+* ``condition_dsp``.
+* Top-level WaveNet ``head`` configs.
+* FiLM.
+* Grouped convolutions.
+* Grouped ``layer1x1`` or ``head1x1``.
+* Paired or gated activations.
+* Packed training plus slimmable WaveNet settings inside the same submodel.
+* Multi-channel input.
+* Multi-channel conditioning audio.
+* Multi-channel output beyond one output channel per packed submodel.
+
+Training behavior
+-----------------
+
+During training, the packed model returns predictions shaped like
+``(batch, submodel, time)``. The trainer computes the configured training loss
+for each submodel prediction against the same target audio and sums the losses.
+
+Validation logs aggregate metrics such as ``val_loss`` and ``ESR`` as well as
+per-submodel metrics such as ``val_loss_packed_0`` and ``ESR_packed_0``. When
+validation is available, the trainer may also save per-submodel best
+checkpoints named ``packed_best_submodel_<i>.ckpt``.
+
+Output files
+------------
+
+The output directory contains the normal full-training artifacts, including
+copied configs, Lightning checkpoints, and optional comparison plots. Packed
+training adds packed-specific export behavior:
+
+* ``model.nam`` has architecture ``SlimmableContainer``.
+* The container embeds complete ordinary ``WaveNet`` models.
+* The packed training model itself is not the runtime format.
+* ``packed_best.json`` is written when per-submodel validation checkpoints are
+  available.
+* ``packed_best_submodel_<i>.ckpt`` files may be written for the best checkpoint
+  of each packed submodel.
+
+If per-submodel best checkpoints are available at final export, the container
+uses them for the corresponding extracted submodels. Otherwise final export
+falls back to the current or aggregate checkpoint behavior used by the trainer.
+
+Troubleshooting
+---------------
+
+Compatibility validation errors usually mean the submodel configs differ in
+temporal architecture or use a feature listed above as unsupported. Check the
+corresponding layer arrays first: depth, kernel sizes, dilations, activation
+configuration, ``head_scale``, head path, and mono input/output settings are
+the most common places to look.
+
+Packed training can use more registered parameters than the sum of the
+individual submodels because the packed tensors include masked off-block
+weights. Those masked weights are kept out of the independent submodel paths
+during training and are not exported as a packed runtime graph.

--- a/nam/models/base.py
+++ b/nam/models/base.py
@@ -208,6 +208,10 @@ class BaseNet(_Base):
         super().__init__(*args, **kwargs)
         self._mps_65536_fallback = False
 
+    @property
+    def _mps_fallback_cat_dim(self) -> int:
+        return 1
+
     def forward(self, x: _torch.Tensor, pad_start: _Optional[bool] = None, **kwargs):
         pad_start = self.pad_start_default if pad_start is None else pad_start
         scalar = x.ndim == 1
@@ -279,7 +283,7 @@ class BaseNet(_Base):
                 # Bit hacky, but correct.
                 if j == x.shape[1]:
                     break
-            return _torch.cat(out_list, dim=1)
+            return _torch.cat(out_list, dim=self._mps_fallback_cat_dim)
 
     @_abc.abstractmethod
     def _forward(self, x: _torch.Tensor, **kwargs) -> _torch.Tensor:

--- a/nam/models/factory.py
+++ b/nam/models/factory.py
@@ -15,6 +15,7 @@ from .conv_net import ConvNet as _ConvNet
 from .linear import Linear as _Linear
 from .recurrent import LSTM as _LSTM
 from .sequential import Sequential as _Sequential
+from .wavenet import PackedWaveNet as _PackedWaveNet
 from .wavenet import WaveNet as _WaveNet
 
 _logger = _logging.getLogger(__name__)
@@ -25,6 +26,7 @@ _model_net_init_registry = {
     "LSTM": _LSTM.init_from_config,
     "Sequential": _Sequential.init_from_config,
     "WaveNet": _WaveNet.init_from_config,
+    "PackedWaveNet": _PackedWaveNet.init_from_config,
 }
 
 

--- a/nam/models/wavenet/__init__.py
+++ b/nam/models/wavenet/__init__.py
@@ -1,71 +1,7 @@
-# File: wavenet.py
-# Created Date: Friday July 29th 2022
-# Author: Steven Atkinson (steven@atkinson.mn)
-
 """
 WaveNet implementation
 https://arxiv.org/abs/1609.03499
 """
 
-import logging as _logging
-from typing import Dict as _Dict
-from typing import Optional as _Optional
-from typing import Sequence as _Sequence
-
-import numpy as _np
-import torch as _torch
-
-from .._abc import ImportsWeights as _ImportsWeights
-from ..base import BaseNet as _BaseNet
-from ._wavenet import WaveNet as _WaveNet
-
-_logger = _logging.getLogger(__name__)
-
-
-class WaveNet(_BaseNet, _ImportsWeights):
-    def __init__(
-        self, wavenet: _WaveNet, sample_rate: _Optional[float] = None, **kwargs
-    ):
-        super().__init__(sample_rate=sample_rate)
-        self._net = wavenet
-
-    @classmethod
-    def parse_config(cls, config: _Dict) -> _Dict:
-        config = super().parse_config(config)
-        sample_rate = config.pop("sample_rate", None)
-        wavenet = _WaveNet.init_from_config(config)
-
-        return {"sample_rate": sample_rate, "wavenet": wavenet}
-
-    @property
-    def pad_start_default(self) -> bool:
-        return True
-
-    @property
-    def receptive_field(self) -> int:
-        return self._net.receptive_field
-
-    def import_weights(self, weights: _Sequence[float], i: int = 0) -> int:
-        weights_tensor = (
-            weights if isinstance(weights, _torch.Tensor) else _torch.Tensor(weights)
-        )
-        return self._net.import_weights(weights_tensor, i)
-
-    def _export_config(self):
-        return self._net.export_config(sample_rate=self.sample_rate)
-
-    def _export_weights(self) -> _np.ndarray:
-        return self._net.export_weights()
-
-    def _forward(self, x, **kwargs):
-        if len(kwargs) > 0:
-            raise ValueError("WaveNet does not support kwargs")
-        if x.ndim == 2:
-            x = x[:, None, :]
-        if self.training and self._net.is_slimmable():
-            with self._net.context_adjust_to_random():
-                y = self._net(x)
-        else:
-            y = self._net(x)
-        assert y.shape[1] == 1
-        return y[:, 0, :]
+from ._packed_wavenet import PackedWaveNet
+from ._wavenet_wrapper import WaveNet

--- a/nam/models/wavenet/_layer_array.py
+++ b/nam/models/wavenet/_layer_array.py
@@ -20,6 +20,13 @@ from . import _conv
 from ._conv import InputMixer as _InputMixer
 from ._conv import class_set as _basic_class_set
 from ._film import FiLM as _FiLM
+from ._packed_conv import PackedHead1x1 as _PackedHead1x1
+from ._packed_conv import PackedHeadRechannel as _PackedHeadRechannel
+from ._packed_conv import PackedInputMixer as _PackedInputMixer
+from ._packed_conv import PackedLayer1x1 as _PackedLayer1x1
+from ._packed_conv import PackedLayerConv as _PackedLayerConv
+from ._packed_conv import PackedRechannelIn as _PackedRechannelIn
+from ._packed_conv import segments_from_sizes as _segments_from_sizes
 from ._slimmable import SLIMMABLE_METHOD as _SLIMMABLE_METHOD
 from ._slimmable import Slimmable as _Slimmable
 from ._slimmable_conv import SlimmableConv1dBase as _SlimmableConv1dBase
@@ -109,6 +116,7 @@ def _get_conv_class_set(slimmable_config: _Optional[dict]) -> _conv.ClassSet:
 def _get_conv_factory_set(
     slimmable_config: _Optional[dict],
     *,
+    packing_config: _Optional[dict] = None,
     is_first: bool,
     is_last: bool,
     input_size: int,
@@ -123,6 +131,16 @@ def _get_conv_factory_set(
     When allowed_channels is in slimmable kwargs, returns factories that inject
     allowed_in_channels/allowed_out_channels. Otherwise returns the class set.
     """
+    if slimmable_config is not None and packing_config is not None:
+        raise ValueError("slimmable and packing configs are mutually exclusive")
+    if packing_config is not None:
+        return _get_packed_conv_factory_set(
+            packing_config,
+            is_first=is_first,
+            input_size=input_size,
+            condition_size=condition_size,
+        )
+
     conv_class_set = _get_conv_class_set(slimmable_config)
     allowed = (
         slimmable_config.get("kwargs", {}).get("allowed_channels")
@@ -251,6 +269,128 @@ def _get_conv_factory_set(
             is_last=is_last,
             boosting=boosting,
             init_strategy=init_strategy,
+            **kwargs,
+        )
+
+    return _ConvFactorySet(
+        RechannelIn=rechannel_in_factory,
+        LayerConv=layer_conv_factory,
+        InputMixer=input_mixer_factory,
+        Layer1x1=layer1x1_factory,
+        Head1x1=head1x1_factory,
+        HeadRechannel=head_rechannel_factory,
+    )
+
+
+def _get_packed_conv_factory_set(
+    packing_config: dict,
+    *,
+    is_first: bool,
+    input_size: int,
+    condition_size: int,
+) -> _ConvFactorySet:
+    channels = tuple(packing_config["channels"])
+    input_channels = tuple(packing_config["input_channels"])
+    bottleneck = tuple(packing_config["bottleneck"])
+    head1x1_out_channels = tuple(packing_config["head1x1_out_channels"])
+    head_rechannel_in_channels = tuple(packing_config["head_rechannel_in_channels"])
+    head_out_channels = tuple(packing_config["head_out_channels"])
+
+    residual_segments = _segments_from_sizes(channels)
+    bottleneck_segments = _segments_from_sizes(bottleneck)
+    input_segments = (
+        ((0, input_size),) if is_first else _segments_from_sizes(input_channels)
+    )
+    condition_segments = ((0, condition_size),)
+    head1x1_segments = _segments_from_sizes([c for c in head1x1_out_channels if c > 0])
+    head_rechannel_input_segments = _segments_from_sizes(head_rechannel_in_channels)
+    head_output_segments = _segments_from_sizes(head_out_channels)
+
+    def rechannel_in_factory(
+        in_ch: int, out_ch: int, *args: _Any, **kwargs: _Any
+    ) -> _Any:
+        return _PackedRechannelIn(
+            in_ch,
+            out_ch,
+            *args,
+            input_segments=input_segments,
+            output_segments=residual_segments,
+            shared_input=is_first,
+            **kwargs,
+        )
+
+    def layer_conv_factory(
+        in_ch: int,
+        out_ch: int,
+        *args: _Any,
+        output_paired: bool = False,
+        **kwargs: _Any,
+    ) -> _Any:
+        # Packed config validation excludes paired activations for now, so the
+        # dilated-conv output maps directly onto the per-submodel bottleneck blocks.
+        if output_paired:
+            raise NotImplementedError(
+                "PackedWaveNet does not yet support paired/gated activations"
+            )
+        return _PackedLayerConv(
+            in_ch,
+            out_ch,
+            *args,
+            input_segments=residual_segments,
+            output_segments=bottleneck_segments,
+            **kwargs,
+        )
+
+    def input_mixer_factory(
+        in_ch: int,
+        out_ch: int,
+        *args: _Any,
+        output_paired: bool = False,
+        **kwargs: _Any,
+    ) -> _Any:
+        if output_paired:
+            raise NotImplementedError(
+                "PackedWaveNet does not yet support paired/gated activations"
+            )
+        return _PackedInputMixer(
+            in_ch,
+            out_ch,
+            *args,
+            input_segments=condition_segments,
+            output_segments=bottleneck_segments,
+            shared_input=True,
+            **kwargs,
+        )
+
+    def layer1x1_factory(in_ch: int, out_ch: int, *args: _Any, **kwargs: _Any) -> _Any:
+        return _PackedLayer1x1(
+            in_ch,
+            out_ch,
+            *args,
+            input_segments=bottleneck_segments,
+            output_segments=residual_segments,
+            **kwargs,
+        )
+
+    def head1x1_factory(in_ch: int, out_ch: int, *args: _Any, **kwargs: _Any) -> _Any:
+        return _PackedHead1x1(
+            in_ch,
+            out_ch,
+            *args,
+            input_segments=bottleneck_segments,
+            output_segments=head1x1_segments,
+            **kwargs,
+        )
+
+    def head_rechannel_factory(
+        in_ch: int, out_ch: int, *args: _Any, **kwargs: _Any
+    ) -> _Any:
+        return _PackedHeadRechannel(
+            in_ch,
+            out_ch,
+            *args,
+            input_segments=head_rechannel_input_segments,
+            output_segments=head_output_segments,
             **kwargs,
         )
 
@@ -720,17 +860,21 @@ class LayerArray(_nn.Module, _InitializableFromConfig):
         groups_input = config.pop("groups_input", 1)
         groups_input_mixin = config.pop("groups_input_mixin", 1)
         slimmable_config = config.pop("slimmable", None)
+        packing_config = config.pop("packing", None)
 
         if slimmable_config is not None and head_cfg.kernel_size != 1:
             raise NotImplementedError(
                 "Slimmable training with head rechannel kernel_size != 1 is not supported"
             )
+        if slimmable_config is not None and packing_config is not None:
+            raise ValueError("slimmable and packing configs are mutually exclusive")
 
         head_rechannel_in_channels = (
             head1x1_config.out_channels if head1x1_config.active else bottleneck
         )
         conv_factory_set = _get_conv_factory_set(
             slimmable_config,
+            packing_config=packing_config,
             is_first=is_first,
             is_last=is_last,
             input_size=input_size,

--- a/nam/models/wavenet/_packed.py
+++ b/nam/models/wavenet/_packed.py
@@ -1,0 +1,394 @@
+"""
+Packed WaveNet config validation and layout construction.
+"""
+
+import json as _json
+from copy import deepcopy as _deepcopy
+from dataclasses import dataclass as _dataclass
+from typing import Any as _Any
+from typing import Dict as _Dict
+from typing import Optional as _Optional
+from typing import Sequence as _Sequence
+
+from .._activations import PairingActivation as _PairingActivation
+from .._activations import get_activation as _get_activation
+
+_FILM_NAMES = (
+    "conv_pre_film",
+    "conv_post_film",
+    "input_mixin_pre_film",
+    "input_mixin_post_film",
+    "activation_pre_film",
+    "activation_post_film",
+    "layer1x1_post_film",
+    "head1x1_post_film",
+)
+
+
+@_dataclass(frozen=True)
+class PackedSubmodelSpec:
+    name: str
+    config: _Dict[str, _Any]
+
+
+@_dataclass(frozen=True)
+class PackedLayerArrayLayout:
+    index: int
+    is_first: bool
+    is_last: bool
+    input_channels: tuple[int, ...]
+    channels: tuple[int, ...]
+    bottleneck: tuple[int, ...]
+    head1x1_out_channels: tuple[int, ...]
+    head_rechannel_in_channels: tuple[int, ...]
+    head_out_channels: tuple[int, ...]
+
+    def as_packing_config(self) -> _Dict[str, _Any]:
+        return {
+            "num_submodels": len(self.channels),
+            "input_channels": list(self.input_channels),
+            "channels": list(self.channels),
+            "bottleneck": list(self.bottleneck),
+            "head1x1_out_channels": list(self.head1x1_out_channels),
+            "head_rechannel_in_channels": list(self.head_rechannel_in_channels),
+            "head_out_channels": list(self.head_out_channels),
+        }
+
+
+@_dataclass(frozen=True)
+class PackedWaveNetSpec:
+    submodels: tuple[PackedSubmodelSpec, ...]
+    layer_layouts: tuple[PackedLayerArrayLayout, ...]
+    export_config: _Dict[str, _Any]
+
+    @property
+    def num_submodels(self) -> int:
+        return len(self.submodels)
+
+    @property
+    def submodel_names(self) -> tuple[str, ...]:
+        return tuple(s.name for s in self.submodels)
+
+    @property
+    def submodel_configs(self) -> tuple[_Dict[str, _Any], ...]:
+        return tuple(_deepcopy(s.config) for s in self.submodels)
+
+    def to_init_config(self, sample_rate: _Optional[float] = None) -> _Dict[str, _Any]:
+        config = {
+            "submodels": [
+                {"name": s.name, "config": _deepcopy(s.config)} for s in self.submodels
+            ],
+            "export": _deepcopy(self.export_config),
+        }
+        if sample_rate is not None:
+            config["sample_rate"] = sample_rate
+        return config
+
+
+def build_packed_wavenet_config(spec: PackedWaveNetSpec) -> _Dict[str, _Any]:
+    reference_config = spec.submodels[0].config
+    packed_layers = []
+    for layout in spec.layer_layouts:
+        ref = _deepcopy(reference_config["layers_configs"][layout.index])
+        ref["input_size"] = (
+            reference_config["layers_configs"][layout.index]["input_size"]
+            if layout.is_first
+            else sum(layout.input_channels)
+        )
+        ref["condition_size"] = reference_config["layers_configs"][layout.index][
+            "condition_size"
+        ]
+        ref["channels"] = sum(layout.channels)
+        ref["bottleneck"] = sum(layout.bottleneck)
+        ref["head"]["out_channels"] = sum(layout.head_out_channels)
+        head1x1 = ref.get("head_1x1_config", {"active": False})
+        if head1x1.get("active", False):
+            head1x1 = _deepcopy(head1x1)
+            head1x1["out_channels"] = sum(layout.head1x1_out_channels)
+            ref["head_1x1_config"] = head1x1
+        ref["packing"] = layout.as_packing_config()
+        packed_layers.append(ref)
+
+    return {
+        "layers_configs": packed_layers,
+        "head": None,
+        "head_scale": reference_config.get("head_scale", 1.0),
+    }
+
+
+def validate_and_build_packed_spec(
+    submodels: _Sequence[_Dict[str, _Any]],
+    export_config: _Optional[_Dict[str, _Any]] = None,
+) -> PackedWaveNetSpec:
+    if len(submodels) < 1:
+        raise ValueError("PackedWaveNet requires at least one submodel")
+    normalized = []
+    for i, submodel in enumerate(submodels):
+        name = str(submodel.get("name", f"submodel_{i}"))
+        if "config" not in submodel:
+            raise KeyError(f"Packed submodel {i} is missing 'config'")
+        normalized.append(
+            PackedSubmodelSpec(name, _normalize_model_config(submodel["config"]))
+        )
+
+    _validate_top_level(normalized)
+    layer_layouts = _validate_layers(normalized)
+    return PackedWaveNetSpec(
+        submodels=tuple(normalized),
+        layer_layouts=tuple(layer_layouts),
+        export_config={} if export_config is None else _deepcopy(export_config),
+    )
+
+
+def _normalize_model_config(config: _Dict[str, _Any]) -> _Dict[str, _Any]:
+    c = _deepcopy(config)
+    if "layers_configs" not in c and "layers" in c:
+        c["layers_configs"] = [
+            _convert_export_layer_config(lc) for lc in c.pop("layers")
+        ]
+    if "layers_configs" not in c:
+        raise KeyError("Packed submodel config must include 'layers_configs'")
+    c["layers_configs"] = [_normalize_layer_config(lc) for lc in c["layers_configs"]]
+    c.setdefault("head", None)
+    c.setdefault("head_scale", 1.0)
+    return c
+
+
+def _normalize_layer_config(layer_config: _Dict[str, _Any]) -> _Dict[str, _Any]:
+    lc = _convert_export_layer_config(layer_config)
+    if "kernel_sizes" in lc and "kernel_size" not in lc:
+        lc["kernel_size"] = lc.pop("kernel_sizes")
+    if "head_1x1_config" not in lc:
+        lc["head_1x1_config"] = {"active": False, "out_channels": 1, "groups": 1}
+    if "layer_1x1_config" not in lc:
+        lc["layer_1x1_config"] = {"active": True, "groups": 1}
+    lc.setdefault("groups_input", 1)
+    lc.setdefault("groups_input_mixin", 1)
+    lc.setdefault("film_params", {})
+    return lc
+
+
+def _convert_export_layer_config(layer_config: _Dict[str, _Any]) -> _Dict[str, _Any]:
+    lc = _deepcopy(layer_config)
+    gating_modes = lc.pop("gating_mode", None)
+    secondary_activations = lc.pop("secondary_activation", None)
+    if "head1x1" in lc and "head_1x1_config" not in lc:
+        lc["head_1x1_config"] = lc.pop("head1x1")
+    if "layer1x1" in lc and "layer_1x1_config" not in lc:
+        lc["layer_1x1_config"] = lc.pop("layer1x1")
+
+    activations = lc.get("activation", [])
+    if gating_modes is not None and secondary_activations is not None:
+        if not isinstance(activations, list):
+            activations = [activations] * len(gating_modes)
+        n = max(len(activations), len(gating_modes), len(secondary_activations))
+        converted = []
+        for i in range(n):
+            primary = activations[i] if i < len(activations) else {"type": "Tanh"}
+            gating_mode = gating_modes[i] if i < len(gating_modes) else "none"
+            secondary = (
+                secondary_activations[i] if i < len(secondary_activations) else None
+            )
+            converted.append(
+                _nam_layer_activation_to_init(primary, gating_mode, secondary)
+            )
+        lc["activation"] = converted
+
+    film_params = lc.pop("film_params", {})
+    for key in _FILM_NAMES:
+        if key in lc:
+            film_params[key] = lc.pop(key)
+    if film_params:
+        lc["film_params"] = film_params
+    return lc
+
+
+def _export_activation_to_init_format(value):
+    if not isinstance(value, dict):
+        return value
+    d = _deepcopy(value)
+    if "type" in d:
+        d["name"] = d.pop("type")
+    if d.get("name") == "PReLU" and "negative_slopes" in d:
+        d["num_parameters"] = len(d["negative_slopes"])
+        del d["negative_slopes"]
+    if set(d) == {"name"}:
+        return d["name"]
+    return d
+
+
+def _nam_layer_activation_to_init(primary, gating_mode: str, secondary):
+    primary = _export_activation_to_init_format(primary)
+    if gating_mode == "none":
+        return primary
+    secondary = _export_activation_to_init_format(secondary)
+    return {
+        "name": "PairMultiply" if gating_mode == "gated" else "PairBlend",
+        "primary": primary,
+        "secondary": secondary,
+    }
+
+
+def _validate_top_level(submodels: _Sequence[PackedSubmodelSpec]) -> None:
+    ref = submodels[0].config
+    if ref.get("condition_dsp") is not None:
+        raise NotImplementedError("PackedWaveNet does not support condition_dsp")
+    if ref.get("head") is not None:
+        raise NotImplementedError("PackedWaveNet does not yet support top-level heads")
+    for submodel in submodels:
+        config = submodel.config
+        if config.get("condition_dsp") is not None:
+            raise NotImplementedError("PackedWaveNet does not support condition_dsp")
+        if config.get("head") is not None:
+            raise NotImplementedError(
+                "PackedWaveNet does not yet support top-level heads"
+            )
+        if config.get("head_scale", 1.0) != ref.get("head_scale", 1.0):
+            raise ValueError("PackedWaveNet submodels must use the same head_scale")
+        if len(config["layers_configs"]) != len(ref["layers_configs"]):
+            raise ValueError(
+                "PackedWaveNet submodels must have the same number of layer arrays"
+            )
+
+
+def _validate_layers(
+    submodels: _Sequence[PackedSubmodelSpec],
+) -> list[PackedLayerArrayLayout]:
+    ref_layers = submodels[0].config["layers_configs"]
+    layouts = []
+    previous_channels = None
+    previous_head_channels = None
+    for layer_array_index, ref in enumerate(ref_layers):
+        is_first = layer_array_index == 0
+        is_last = layer_array_index == len(ref_layers) - 1
+        _validate_reference_layer(ref)
+        ref_kernel_sizes = _kernel_sizes(ref)
+        ref_dilations = tuple(ref["dilations"])
+        ref_activation = _activation_signature(ref["activation"], len(ref_dilations))
+        ref_head = ref["head"]
+        ref_layer1x1 = ref["layer_1x1_config"]
+        ref_head1x1 = ref["head_1x1_config"]
+
+        input_channels = []
+        channels = []
+        bottlenecks = []
+        head1x1_out_channels = []
+        head_rechannel_in_channels = []
+        head_out_channels = []
+
+        for submodel in submodels:
+            layer = submodel.config["layers_configs"][layer_array_index]
+            _validate_reference_layer(layer)
+            if len(layer["dilations"]) != len(ref_dilations):
+                raise ValueError("PackedWaveNet layer arrays must have matching depth")
+            if _kernel_sizes(layer) != ref_kernel_sizes:
+                raise ValueError("PackedWaveNet layer arrays must match kernel sizes")
+            if tuple(layer["dilations"]) != ref_dilations:
+                raise ValueError("PackedWaveNet layer arrays must match dilations")
+            if (
+                _activation_signature(layer["activation"], len(ref_dilations))
+                != ref_activation
+            ):
+                raise ValueError("PackedWaveNet layer activations must match")
+            if layer["head"]["kernel_size"] != ref_head["kernel_size"]:
+                raise ValueError("PackedWaveNet head rechannel kernels must match")
+            if layer["head"].get("bias", True) != ref_head.get("bias", True):
+                raise ValueError("PackedWaveNet head rechannel bias flags must match")
+            if layer["layer_1x1_config"].get("active", True) != ref_layer1x1.get(
+                "active", True
+            ):
+                raise ValueError("PackedWaveNet layer1x1 active flags must match")
+            if layer["head_1x1_config"].get("active", False) != ref_head1x1.get(
+                "active", False
+            ):
+                raise ValueError("PackedWaveNet head1x1 active flags must match")
+
+            expected_input = 1 if is_first else previous_channels[len(input_channels)]
+            if layer["input_size"] != expected_input:
+                raise ValueError(
+                    "PackedWaveNet layer input_size must match previous channels"
+                )
+            if layer["condition_size"] != ref["condition_size"]:
+                raise ValueError("PackedWaveNet condition sizes must match")
+            if is_first and layer["input_size"] != 1:
+                raise NotImplementedError("PackedWaveNet currently supports mono input")
+            if layer["condition_size"] != 1:
+                raise NotImplementedError(
+                    "PackedWaveNet currently supports mono conditioning audio"
+                )
+            if is_last and layer["head"]["out_channels"] != 1:
+                raise NotImplementedError(
+                    "PackedWaveNet currently supports one output channel per submodel"
+                )
+
+            c = int(layer["channels"])
+            b = int(layer.get("bottleneck", c))
+            h1 = int(layer["head_1x1_config"].get("out_channels", 1))
+            h1_active = layer["head_1x1_config"].get("active", False)
+            head_rechannel_in = h1 if h1_active else b
+            if (
+                not is_first
+                and head_rechannel_in != previous_head_channels[len(input_channels)]
+            ):
+                raise ValueError(
+                    "PackedWaveNet layer-array head channels must match the "
+                    "previous layer-array head outputs"
+                )
+            input_channels.append(int(layer["input_size"]))
+            channels.append(c)
+            bottlenecks.append(b)
+            head1x1_out_channels.append(h1 if h1_active else 0)
+            head_rechannel_in_channels.append(head_rechannel_in)
+            head_out_channels.append(int(layer["head"]["out_channels"]))
+
+        layouts.append(
+            PackedLayerArrayLayout(
+                index=layer_array_index,
+                is_first=is_first,
+                is_last=is_last,
+                input_channels=tuple(input_channels),
+                channels=tuple(channels),
+                bottleneck=tuple(bottlenecks),
+                head1x1_out_channels=tuple(head1x1_out_channels),
+                head_rechannel_in_channels=tuple(head_rechannel_in_channels),
+                head_out_channels=tuple(head_out_channels),
+            )
+        )
+        previous_channels = tuple(channels)
+        previous_head_channels = tuple(head_out_channels)
+    return layouts
+
+
+def _validate_reference_layer(layer: _Dict[str, _Any]) -> None:
+    if layer.get("slimmable") is not None:
+        raise NotImplementedError("PackedWaveNet and slimmable WaveNet are exclusive")
+    if layer.get("groups_input", 1) != 1 or layer.get("groups_input_mixin", 1) != 1:
+        raise NotImplementedError("PackedWaveNet does not support grouped convolutions")
+    if layer["layer_1x1_config"].get("groups", 1) != 1:
+        raise NotImplementedError("PackedWaveNet does not support grouped layer1x1")
+    if layer["head_1x1_config"].get("groups", 1) != 1:
+        raise NotImplementedError("PackedWaveNet does not support grouped head1x1")
+    for film_config in layer.get("film_params", {}).values():
+        if isinstance(film_config, dict) and film_config.get("active", False):
+            raise NotImplementedError("PackedWaveNet does not support FiLM")
+    activations = layer["activation"]
+    if not isinstance(activations, list):
+        activations = [activations] * len(layer["dilations"])
+    for activation in activations:
+        if isinstance(_get_activation(activation), _PairingActivation):
+            raise NotImplementedError(
+                "PackedWaveNet does not yet support paired/gated activations"
+            )
+
+
+def _kernel_sizes(layer: _Dict[str, _Any]) -> tuple[int, ...]:
+    kernel_sizes = layer["kernel_size"]
+    if isinstance(kernel_sizes, int):
+        return tuple([kernel_sizes] * len(layer["dilations"]))
+    return tuple(int(k) for k in kernel_sizes)
+
+
+def _activation_signature(activation, num_layers: int) -> tuple[str, ...]:
+    if not isinstance(activation, list):
+        activation = [activation] * num_layers
+    return tuple(_json.dumps(a, sort_keys=True) for a in activation)

--- a/nam/models/wavenet/_packed_conv.py
+++ b/nam/models/wavenet/_packed_conv.py
@@ -1,0 +1,172 @@
+"""
+Masked convolution layers for packed WaveNet training.
+"""
+
+from typing import Sequence as _Sequence
+from typing import Tuple as _Tuple
+
+import torch as _torch
+import torch.nn as _nn
+
+from . import _conv
+
+_Segment = _Tuple[int, int]
+
+
+def segments_from_sizes(sizes: _Sequence[int]) -> _Tuple[_Segment, ...]:
+    """Return ``(start, size)`` channel segments for contiguous channel blocks."""
+    segments = []
+    start = 0
+    for size in sizes:
+        if size < 1:
+            raise ValueError("Packed channel sizes must be positive")
+        segments.append((start, int(size)))
+        start += int(size)
+    return tuple(segments)
+
+
+class PackedConv1dBase(_conv.Conv1d):
+    """
+    Conv1d with an explicit channel mask.
+
+    ``shared_input=True`` means every packed output block can read the same input
+    channels. Otherwise, output block ``i`` reads only input block ``i``.
+    """
+
+    def __init__(
+        self,
+        *args,
+        input_segments: _Sequence[_Segment],
+        output_segments: _Sequence[_Segment],
+        shared_input: bool = False,
+        groups: int = 1,
+        **kwargs,
+    ):
+        if groups != 1:
+            raise NotImplementedError("Packed convolutions require groups == 1")
+        super().__init__(*args, groups=groups, **kwargs)
+        self._input_segments = tuple((int(s), int(n)) for s, n in input_segments)
+        self._output_segments = tuple((int(s), int(n)) for s, n in output_segments)
+        self._shared_input = bool(shared_input)
+        if not self._shared_input and len(self._input_segments) != len(
+            self._output_segments
+        ):
+            raise ValueError(
+                "Packed convolutions require matching input/output block counts"
+            )
+        if len(self._output_segments) == 0:
+            raise ValueError("Packed convolutions require at least one output block")
+
+        mask = _torch.zeros_like(self.weight)
+        for i, (out_start, out_size) in enumerate(self._output_segments):
+            in_start, in_size = self._input_segment_for(i)
+            mask[out_start : out_start + out_size, in_start : in_start + in_size, :] = (
+                1.0
+            )
+        self.register_buffer("_weight_mask", mask)
+        self._reset_packed_parameters()
+        self.apply_mask()
+
+    @property
+    def output_segments(self) -> _Tuple[_Segment, ...]:
+        return self._output_segments
+
+    @property
+    def input_segments(self) -> _Tuple[_Segment, ...]:
+        return self._input_segments
+
+    @property
+    def shared_input(self) -> bool:
+        return self._shared_input
+
+    def get_block_slices(self, submodel_index: int):
+        out_start, out_size = self._output_segments[submodel_index]
+        in_start, in_size = self._input_segment_for(submodel_index)
+        return (
+            slice(out_start, out_start + out_size),
+            slice(in_start, in_start + in_size),
+        )
+
+    def forward(self, input: _torch.Tensor) -> _torch.Tensor:
+        return _nn.functional.conv1d(
+            input,
+            self.weight * self._weight_mask,
+            self.bias,
+            self.stride,
+            self.padding,
+            self.dilation,
+            self.groups,
+        )
+
+    def import_weights(self, weights: _Sequence[float], i: int) -> int:
+        i = super().import_weights(weights, i)
+        self.apply_mask()
+        return i
+
+    def apply_mask(self) -> None:
+        with _torch.no_grad():
+            self.weight.mul_(self._weight_mask)
+
+    def _assert_masked(self) -> None:
+        invalid = self.weight * (1.0 - self._weight_mask)
+        if not _torch.allclose(invalid, _torch.zeros_like(invalid)):
+            raise AssertionError("Packed convolution has non-zero off-block weights")
+
+    def _input_segment_for(self, submodel_index: int) -> _Segment:
+        if self._shared_input:
+            if len(self._input_segments) != 1:
+                raise ValueError("Shared-input packed convs require one input segment")
+            return self._input_segments[0]
+        return self._input_segments[submodel_index]
+
+    def _reset_packed_parameters(self) -> None:
+        with _torch.no_grad():
+            self.weight.zero_()
+            if self.bias is not None:
+                self.bias.zero_()
+            for i, (out_start, out_size) in enumerate(self._output_segments):
+                in_start, in_size = self._input_segment_for(i)
+                temp = _nn.Conv1d(
+                    in_size,
+                    out_size,
+                    self.kernel_size,
+                    stride=self.stride,
+                    padding=self.padding,
+                    dilation=self.dilation,
+                    groups=1,
+                    bias=self.bias is not None,
+                    padding_mode=self.padding_mode,
+                    device=self.weight.device,
+                    dtype=self.weight.dtype,
+                )
+                self.weight[
+                    out_start : out_start + out_size,
+                    in_start : in_start + in_size,
+                    :,
+                ].copy_(temp.weight)
+                if self.bias is not None:
+                    self.bias[out_start : out_start + out_size].copy_(temp.bias)
+
+
+class PackedRechannelIn(_conv.RechannelIn, PackedConv1dBase):
+    pass
+
+
+class PackedLayerConv(_conv.LayerConv, PackedConv1dBase):
+    pass
+
+
+class PackedInputMixer(_conv.InputMixer, PackedConv1dBase):
+    pass
+
+
+class PackedLayer1x1(PackedConv1dBase):
+    pass
+
+
+class PackedHead1x1(PackedConv1dBase):
+    pass
+
+
+class PackedHeadRechannel(_conv.HeadRechannel, PackedConv1dBase):
+    pass

--- a/nam/models/wavenet/_packed_wavenet.py
+++ b/nam/models/wavenet/_packed_wavenet.py
@@ -1,0 +1,373 @@
+"""
+Packed WaveNet public wrapper implementation.
+"""
+
+import json as _json
+from collections.abc import Mapping as _Mapping
+from pathlib import Path as _Path
+from typing import Dict as _Dict
+from typing import Optional as _Optional
+from typing import Sequence as _Sequence
+
+import numpy as _np
+import torch as _torch
+
+from .._abc import ImportsWeights as _ImportsWeights
+from .._constants import MODEL_VERSION as _MODEL_VERSION
+from ..base import BaseNet as _BaseNet
+from ..exportable import _cast_enums
+from ..metadata import UserMetadata as _UserMetadata
+from ._packed import PackedWaveNetSpec as _PackedWaveNetSpec
+from ._packed import build_packed_wavenet_config as _build_packed_wavenet_config
+from ._packed import validate_and_build_packed_spec as _validate_and_build_packed_spec
+from ._packed_conv import PackedConv1dBase as _PackedConv1dBase
+from ._wavenet import WaveNet as _InternalWaveNet
+from ._wavenet_wrapper import WaveNet as _PublicWaveNet
+
+
+class PackedWaveNet(_BaseNet, _ImportsWeights):
+    def __init__(
+        self,
+        wavenet: _InternalWaveNet,
+        spec: _PackedWaveNetSpec,
+        sample_rate: _Optional[float] = None,
+    ):
+        super().__init__(sample_rate=sample_rate)
+        self._net = wavenet
+        self._spec = spec
+        self.apply_mask()
+
+    @classmethod
+    def parse_config(cls, config: _Dict) -> _Dict:
+        config = super().parse_config(config)
+        sample_rate = config.pop("sample_rate", None)
+        submodels = config.pop("submodels")
+        export_config = config.pop("export", {})
+        if config:
+            raise ValueError(f"Unexpected PackedWaveNet config keys: {sorted(config)}")
+        spec = _validate_and_build_packed_spec(submodels, export_config=export_config)
+        wavenet = _InternalWaveNet.init_from_config(_build_packed_wavenet_config(spec))
+        return {"sample_rate": sample_rate, "wavenet": wavenet, "spec": spec}
+
+    @property
+    def pad_start_default(self) -> bool:
+        return True
+
+    @property
+    def receptive_field(self) -> int:
+        return self._net.receptive_field
+
+    @property
+    def num_submodels(self) -> int:
+        return self._spec.num_submodels
+
+    @property
+    def submodel_names(self) -> tuple[str, ...]:
+        return self._spec.submodel_names
+
+    @property
+    def submodel_configs(self) -> tuple[_Dict, ...]:
+        return self._spec.submodel_configs
+
+    @property
+    def _mps_fallback_cat_dim(self) -> int:
+        return -1
+
+    def import_weights(self, weights: _Sequence[float], i: int = 0) -> int:
+        weights_tensor = (
+            weights if isinstance(weights, _torch.Tensor) else _torch.Tensor(weights)
+        )
+        i = self._net.import_weights(weights_tensor, i)
+        self.apply_mask()
+        return i
+
+    def import_submodel(self, submodel_index: int, submodel: _PublicWaveNet) -> None:
+        packed_convs = list(_iter_wavenet_convs(self._net))
+        ordinary_convs = list(_iter_wavenet_convs(submodel._net))
+        if len(packed_convs) != len(ordinary_convs):
+            raise ValueError("Packed and ordinary WaveNet structures do not match")
+        for packed_conv, ordinary_conv in zip(packed_convs, ordinary_convs):
+            _copy_ordinary_conv_to_packed(packed_conv, ordinary_conv, submodel_index)
+        self.apply_mask()
+
+    def extract_submodel(self, submodel_index: int) -> _PublicWaveNet:
+        if submodel_index < 0 or submodel_index >= self.num_submodels:
+            raise IndexError(submodel_index)
+        self.apply_mask()
+
+        submodel = _PublicWaveNet.init_from_config(
+            self._spec.submodel_configs[submodel_index]
+        )
+        submodel.sample_rate = self.sample_rate
+        if self.device is not None:
+            submodel.to(self.device)
+        packed_convs = list(_iter_wavenet_convs(self._net))
+        ordinary_convs = list(_iter_wavenet_convs(submodel._net))
+        if len(packed_convs) != len(ordinary_convs):
+            raise ValueError("Packed and ordinary WaveNet structures do not match")
+        for packed_conv, ordinary_conv in zip(packed_convs, ordinary_convs):
+            _copy_packed_conv_to_ordinary(packed_conv, ordinary_conv, submodel_index)
+        submodel.train(self.training)
+        return submodel
+
+    def export(
+        self,
+        outdir: _Path,
+        include_snapshot: bool = False,
+        basename: str = "model",
+        user_metadata: _Optional[_UserMetadata] = None,
+        other_metadata: _Optional[dict] = None,
+    ):
+        self.export_container(
+            outdir,
+            include_snapshot=include_snapshot,
+            basename=basename,
+            user_metadata=user_metadata,
+            other_metadata=other_metadata,
+        )
+
+    def export_container(
+        self,
+        outdir: _Path,
+        include_snapshot: bool = False,
+        basename: str = "model",
+        checkpoint_paths_by_submodel: _Optional[_Sequence[_Optional[str]]] = None,
+        user_metadata: _Optional[_UserMetadata] = None,
+        other_metadata: _Optional[dict] = None,
+    ) -> _Dict:
+        models = []
+        checkpoint_paths = self._normalize_checkpoint_paths(
+            checkpoint_paths_by_submodel
+        )
+        for i in range(self.num_submodels):
+            source = self
+            checkpoint_path = (
+                checkpoint_paths[i] if checkpoint_paths is not None else None
+            )
+            if checkpoint_path is not None:
+                source = self._load_packed_checkpoint(checkpoint_path)
+            models.append(source.extract_submodel(i)._get_export_dict())
+
+        container = {
+            "version": _MODEL_VERSION,
+            "metadata": self._get_non_user_metadata(),
+            "architecture": "SlimmableContainer",
+            "config": {
+                "submodels": [
+                    {"max_value": max_value, "model": model}
+                    for max_value, model in zip(self._container_max_values(), models)
+                ]
+            },
+            "weights": [],
+        }
+        if self.sample_rate is not None:
+            container["sample_rate"] = self.sample_rate
+        if user_metadata is not None:
+            container["metadata"].update(_cast_enums(user_metadata.model_dump()))
+        if other_metadata is not None:
+            container["metadata"].update(_cast_enums(other_metadata))
+
+        outdir = _Path(outdir)
+        with open(_Path(outdir, f"{basename}{self.FILE_EXTENSION}"), "w") as fp:
+            _json.dump(container, fp)
+        if include_snapshot:
+            x, y = self._export_input_output()
+            _np.save(_Path(outdir, "test_inputs.npy"), x)
+            _np.save(_Path(outdir, "test_outputs.npy"), y)
+        return container
+
+    def apply_mask(self) -> None:
+        for module in self.modules():
+            if isinstance(module, _PackedConv1dBase):
+                module.apply_mask()
+
+    def _assert_masked(self) -> None:
+        for module in self.modules():
+            if isinstance(module, _PackedConv1dBase):
+                module._assert_masked()
+
+    def _export_config(self):
+        return self._spec.to_init_config(sample_rate=self.sample_rate)
+
+    def _export_weights(self) -> _np.ndarray:
+        self.apply_mask()
+        return self._net.export_weights()
+
+    def _forward(self, x, **kwargs):
+        if len(kwargs) > 0:
+            raise ValueError("PackedWaveNet does not support kwargs")
+        if x.ndim == 2:
+            x = x[:, None, :]
+        y = self._net(x)
+        assert y.shape[1] == self.num_submodels
+        return y
+
+    def _container_max_values(self) -> list[float]:
+        configured = self._spec.export_config.get("container_max_values", "uniform")
+        if configured == "uniform":
+            values = [(i + 1) / self.num_submodels for i in range(self.num_submodels)]
+            values[-1] = 1.0
+            return values
+        if not isinstance(configured, list):
+            raise ValueError("container_max_values must be 'uniform' or a list")
+        if len(configured) != self.num_submodels:
+            raise ValueError("container_max_values length must match submodels")
+        values = [float(v) for v in configured]
+        values[-1] = 1.0
+        if values != sorted(values):
+            raise ValueError("container_max_values must be sorted")
+        return values
+
+    def _normalize_checkpoint_paths(self, paths):
+        if paths is None:
+            return None
+        if isinstance(paths, dict):
+            return [paths.get(i) for i in range(self.num_submodels)]
+        if len(paths) != self.num_submodels:
+            raise ValueError("checkpoint_paths_by_submodel length must match submodels")
+        return list(paths)
+
+    def _load_packed_checkpoint(self, checkpoint_path: str) -> "PackedWaveNet":
+        try:
+            checkpoint = _torch.load(
+                checkpoint_path, map_location="cpu", weights_only=False
+            )
+        except TypeError:
+            checkpoint = _torch.load(checkpoint_path, map_location="cpu")
+        sample_rate = (
+            checkpoint.get("sample_rate")
+            if isinstance(checkpoint, _Mapping) and "sample_rate" in checkpoint
+            else None
+        )
+        packed = self.__class__.init_from_config(
+            self._spec.to_init_config(sample_rate=sample_rate)
+        )
+        state_dict = _extract_checkpoint_state_dict(checkpoint, checkpoint_path)
+        state_dict = _normalize_packed_checkpoint_state_dict(
+            state_dict, packed.state_dict().keys(), checkpoint_path
+        )
+        try:
+            packed.load_state_dict(state_dict, strict=True)
+        except RuntimeError as e:
+            raise RuntimeError(
+                f"Failed to load packed checkpoint {checkpoint_path}: {e}"
+            ) from e
+        if sample_rate is not None:
+            packed.sample_rate = sample_rate
+        elif packed.sample_rate is None and self.sample_rate is not None:
+            packed.sample_rate = self.sample_rate
+        packed.apply_mask()
+        return packed
+
+
+def _extract_checkpoint_state_dict(checkpoint, checkpoint_path: str) -> _Mapping:
+    if isinstance(checkpoint, _Mapping) and "state_dict" in checkpoint:
+        state_dict = checkpoint["state_dict"]
+    elif hasattr(checkpoint, "state_dict"):
+        state_dict = checkpoint.state_dict()
+    else:
+        state_dict = checkpoint
+    if not isinstance(state_dict, _Mapping):
+        raise RuntimeError(
+            f"Packed checkpoint {checkpoint_path} does not contain a state_dict mapping"
+        )
+    non_string_keys = [k for k in state_dict if not isinstance(k, str)]
+    if non_string_keys:
+        raise RuntimeError(
+            f"Packed checkpoint {checkpoint_path} has unexpected non-string "
+            f"state_dict keys: {_summarize_keys(non_string_keys)}"
+        )
+    return state_dict
+
+
+def _normalize_packed_checkpoint_state_dict(
+    state_dict: _Mapping, expected_keys, checkpoint_path: str
+) -> _Mapping:
+    expected = set(expected_keys)
+    source = set(state_dict.keys())
+    if source == expected:
+        return state_dict
+
+    lightning_prefix = "_net."
+    if source and all(k.startswith(lightning_prefix) for k in source):
+        normalized = {
+            k[len(lightning_prefix) :]: v for k, v in state_dict.items()
+        }
+        normalized_keys = set(normalized.keys())
+        if normalized_keys == expected:
+            return normalized
+        raise RuntimeError(
+            _format_checkpoint_key_mismatch(
+                checkpoint_path,
+                expected,
+                normalized_keys,
+                "after stripping one leading '_net.' prefix",
+            )
+        )
+
+    raise RuntimeError(
+        _format_checkpoint_key_mismatch(
+            checkpoint_path,
+            expected,
+            source,
+            "for raw PackedWaveNet format",
+        )
+    )
+
+
+def _format_checkpoint_key_mismatch(
+    checkpoint_path: str, expected: set[str], actual: set[str], context: str
+) -> str:
+    missing = expected - actual
+    unexpected = actual - expected
+    return (
+        f"Packed checkpoint {checkpoint_path} does not match PackedWaveNet "
+        f"state_dict keys {context}; missing keys: {_summarize_keys(missing)}; "
+        f"unexpected keys: {_summarize_keys(unexpected)}"
+    )
+
+
+def _summarize_keys(keys, limit: int = 8) -> str:
+    keys = sorted(str(k) for k in keys)
+    if not keys:
+        return "[]"
+    shown = keys[:limit]
+    suffix = "" if len(keys) <= limit else f", ... ({len(keys) - limit} more)"
+    return "[" + ", ".join(shown) + suffix + "]"
+
+
+def _iter_wavenet_convs(wavenet: _InternalWaveNet):
+    if wavenet._condition_dsp is not None:
+        raise NotImplementedError("PackedWaveNet does not support condition_dsp")
+    if wavenet._head is not None:
+        raise NotImplementedError("PackedWaveNet does not yet support top-level heads")
+    for layer_array in wavenet._layer_arrays:
+        yield layer_array._rechannel
+        for layer in layer_array._layers:
+            yield layer.conv
+            yield layer.input_mixer
+            if layer.layer1x1 is not None:
+                yield layer.layer1x1
+            if layer.head1x1 is not None:
+                yield layer.head1x1
+        yield layer_array._head_rechannel
+
+
+def _copy_packed_conv_to_ordinary(
+    packed_conv: _PackedConv1dBase, ordinary_conv, submodel_index: int
+) -> None:
+    out_slice, in_slice = packed_conv.get_block_slices(submodel_index)
+    with _torch.no_grad():
+        ordinary_conv.weight.copy_(packed_conv.weight[out_slice, in_slice, :])
+        if ordinary_conv.bias is not None:
+            ordinary_conv.bias.copy_(packed_conv.bias[out_slice])
+
+
+def _copy_ordinary_conv_to_packed(
+    packed_conv: _PackedConv1dBase, ordinary_conv, submodel_index: int
+) -> None:
+    out_slice, in_slice = packed_conv.get_block_slices(submodel_index)
+    with _torch.no_grad():
+        packed_conv.weight[out_slice, in_slice, :].copy_(ordinary_conv.weight)
+        if packed_conv.bias is not None and ordinary_conv.bias is not None:
+            packed_conv.bias[out_slice].copy_(ordinary_conv.bias)

--- a/nam/models/wavenet/_wavenet_wrapper.py
+++ b/nam/models/wavenet/_wavenet_wrapper.py
@@ -1,0 +1,67 @@
+# File: wavenet.py
+# Created Date: Friday July 29th 2022
+# Author: Steven Atkinson (steven@atkinson.mn)
+
+"""
+WaveNet public wrapper implementation.
+"""
+
+from typing import Dict as _Dict
+from typing import Optional as _Optional
+from typing import Sequence as _Sequence
+
+import numpy as _np
+import torch as _torch
+
+from .._abc import ImportsWeights as _ImportsWeights
+from ..base import BaseNet as _BaseNet
+from ._wavenet import WaveNet as _WaveNet
+
+
+class WaveNet(_BaseNet, _ImportsWeights):
+    def __init__(
+        self, wavenet: _WaveNet, sample_rate: _Optional[float] = None, **kwargs
+    ):
+        super().__init__(sample_rate=sample_rate)
+        self._net = wavenet
+
+    @classmethod
+    def parse_config(cls, config: _Dict) -> _Dict:
+        config = super().parse_config(config)
+        sample_rate = config.pop("sample_rate", None)
+        wavenet = _WaveNet.init_from_config(config)
+
+        return {"sample_rate": sample_rate, "wavenet": wavenet}
+
+    @property
+    def pad_start_default(self) -> bool:
+        return True
+
+    @property
+    def receptive_field(self) -> int:
+        return self._net.receptive_field
+
+    def import_weights(self, weights: _Sequence[float], i: int = 0) -> int:
+        weights_tensor = (
+            weights if isinstance(weights, _torch.Tensor) else _torch.Tensor(weights)
+        )
+        return self._net.import_weights(weights_tensor, i)
+
+    def _export_config(self):
+        return self._net.export_config(sample_rate=self.sample_rate)
+
+    def _export_weights(self) -> _np.ndarray:
+        return self._net.export_weights()
+
+    def _forward(self, x, **kwargs):
+        if len(kwargs) > 0:
+            raise ValueError("WaveNet does not support kwargs")
+        if x.ndim == 2:
+            x = x[:, None, :]
+        if self.training and self._net.is_slimmable():
+            with self._net.context_adjust_to_random():
+                y = self._net(x)
+        else:
+            y = self._net(x)
+        assert y.shape[1] == 1
+        return y[:, 0, :]

--- a/nam/train/full.py
+++ b/nam/train/full.py
@@ -68,7 +68,7 @@ def _plot(
         tx = len(ds.x) / 48_000
         print(f"Run (t={tx:.2f})")
         t0 = _time()
-        output = model(ds.x).flatten().cpu().numpy()
+        output = model(ds.x).cpu().numpy()
         t1 = _time()
         try:
             rt = f"{tx / (t1 - t0):.2f}"
@@ -76,12 +76,52 @@ def _plot(
             rt = "???"
         print(f"Took {t1 - t0:.2f} ({rt}x)")
 
+    if output.ndim == 2:
+        for i in range(output.shape[0]):
+            packed_savefig = None
+            if savefig is not None:
+                savefig = _Path(savefig)
+                packed_savefig = savefig.with_name(
+                    f"{savefig.stem}_packed_{i}{savefig.suffix}"
+                )
+            _plot_arrays(
+                output[i],
+                ds.y,
+                savefig=packed_savefig,
+                show=show and i == output.shape[0] - 1,
+                window_start=window_start,
+                window_end=window_end,
+                title_prefix=f"Packed {i}: ",
+            )
+        return
+
+    output = output.flatten()
+    _plot_arrays(
+        output,
+        ds.y,
+        savefig=savefig,
+        show=show,
+        window_start=window_start,
+        window_end=window_end,
+    )
+
+
+def _plot_arrays(
+    output,
+    target,
+    savefig=None,
+    show=True,
+    window_start: _Optional[int] = None,
+    window_end: _Optional[int] = None,
+    title_prefix: str = "",
+):
+
     _plt.figure(figsize=(16, 5))
     _plt.plot(output[window_start:window_end], label="Prediction")
-    _plt.plot(ds.y[window_start:window_end], linestyle="--", label="Target")
-    nrmse = _rms(_torch.Tensor(output) - ds.y) / _rms(ds.y)
+    _plt.plot(target[window_start:window_end], linestyle="--", label="Target")
+    nrmse = _rms(_torch.Tensor(output) - target) / _rms(target)
     esr = nrmse**2
-    _plt.title(f"ESR={esr:.3f}")
+    _plt.title(f"{title_prefix}ESR={esr:.3f}")
     _plt.legend()
     if savefig is not None:
         _plt.savefig(savefig)
@@ -89,7 +129,7 @@ def _plot(
         _plt.show()
 
 
-def _create_callbacks(learning_config):
+def _create_callbacks(learning_config, packed: bool = False):
     """
     Checkpointing, essentially
     """
@@ -119,14 +159,24 @@ def _create_callbacks(learning_config):
     checkpoint_epoch = _pl.callbacks.model_checkpoint.ModelCheckpoint(
         filename="checkpoint_epoch_{epoch:04d}", every_n_epochs=1
     )
+    callbacks = [checkpoint_best]
+    if packed:
+        callbacks.extend(
+            [
+                _lightning_module.PackedBestCheckpoint(),
+                _lightning_module.PackedMaskCallback(),
+            ]
+        )
     if not validate_inside_epoch:
-        return [checkpoint_best, checkpoint_epoch]
+        callbacks.append(checkpoint_epoch)
+        return callbacks
     else:
         # The last validation pass, whether at the end of an epoch or not
         checkpoint_last = _pl.callbacks.model_checkpoint.ModelCheckpoint(
             filename="checkpoint_last_{epoch:04d}_{step}", **kwargs
         )
-        return [checkpoint_best, checkpoint_last, checkpoint_epoch]
+        callbacks.extend([checkpoint_last, checkpoint_epoch])
+        return callbacks
 
 
 def main(
@@ -148,7 +198,13 @@ def main(
         with open(_Path(outdir, f"config_{basename}.json"), "w") as fp:
             _json.dump(config, fp, indent=4)
 
-    model = _lightning_module.LightningModule.init_from_config(model_config)
+    is_packed = model_config["net"]["name"] == "PackedWaveNet"
+    lightning_cls = (
+        _lightning_module.PackedLightningModule
+        if is_packed
+        else _lightning_module.LightningModule
+    )
+    model = lightning_cls.init_from_config(model_config)
     # Add receptive field to data config:
     data_config["common"] = data_config.get("common", {})
     if "nx" in data_config["common"]:
@@ -177,8 +233,13 @@ def main(
         dataset_validation, **learning_config["val_dataloader"]
     )
 
+    callbacks = _create_callbacks(learning_config, packed=is_packed)
+    packed_best_callback = next(
+        (c for c in callbacks if isinstance(c, _lightning_module.PackedBestCheckpoint)),
+        None,
+    )
     trainer = _pl.Trainer(
-        callbacks=_create_callbacks(learning_config),
+        callbacks=callbacks,
         default_root_dir=outdir,
         **learning_config["trainer"],
     )
@@ -198,9 +259,9 @@ def main(
         # Go to best checkpoint
         best_checkpoint = trainer.checkpoint_callback.best_model_path
         if best_checkpoint != "":
-            model = _lightning_module.LightningModule.load_from_checkpoint(
+            model = lightning_cls.load_from_checkpoint(
                 trainer.checkpoint_callback.best_model_path,
-                **_lightning_module.LightningModule.parse_config(model_config),
+                **lightning_cls.parse_config(model_config),
             )
         model.cpu()
         model.eval()
@@ -215,7 +276,19 @@ def main(
             )
             _plot(model, dataset_validation, show=not no_show)
         # Export!
-        model.net.export(outdir)
+        if is_packed:
+            checkpoint_paths = (
+                None
+                if packed_best_callback is None
+                or not packed_best_callback.checkpoint_paths
+                else packed_best_callback.checkpoint_paths
+            )
+            model.net.export_container(
+                outdir,
+                checkpoint_paths_by_submodel=checkpoint_paths,
+            )
+        else:
+            model.net.export(outdir)
 
         # Tear down the datasets
         train_dataloader.dataset.teardown()

--- a/nam/train/lightning_module.py
+++ b/nam/train/lightning_module.py
@@ -11,11 +11,14 @@ For the base *PyTorch* model containing the actual architecture, see `..models.b
 """
 
 import logging as _logging
+import json as _json
 from dataclasses import dataclass as _dataclass
 from enum import Enum as _Enum
+from pathlib import Path as _Path
 from typing import Any as _Any
 from typing import Callable as _Callable
 from typing import Dict as _Dict
+from typing import List as _List
 from typing import NamedTuple as _NamedTuple
 from typing import Optional as _Optional
 from typing import Tuple as _Tuple
@@ -38,6 +41,7 @@ from ..models.losses import mse as _mse
 from ..models.losses import mse_fft as _mse_fft
 from ..models.losses import multi_resolution_stft_loss as _multi_resolution_stft_loss
 from ..models.recurrent import LSTM as _LSTM
+from ..models.wavenet import PackedWaveNet as _PackedWaveNet
 from ..models.wavenet import WaveNet as _WaveNet
 from ..util import init as _init
 
@@ -474,4 +478,154 @@ class LightningModule(_pl.LightningModule, _InitializableFromConfig):
             self._mrstft_device = backup_device
             return _multi_resolution_stft_loss(
                 preds, targets, self._mrstft, device=self._mrstft_device
+            )
+
+
+class PackedLightningModule(LightningModule):
+    """
+    Lightning module for packed WaveNet training.
+    """
+
+    @property
+    def net(self) -> _PackedWaveNet:
+        return self._net
+
+    def training_step(self, batch, batch_idx):
+        _, _, loss_dicts = self._shared_step(batch)
+        loss = 0.0
+        for loss_dict in loss_dicts:
+            for v in loss_dict.values():
+                if v.weight is not None and v.weight > 0.0:
+                    loss = loss + v.weight * v.value
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        preds, targets, loss_dicts = self._shared_step(batch)
+        logs = {}
+        val_losses = []
+
+        for i, loss_dict in enumerate(loss_dicts):
+            if "MSE" not in loss_dict:
+                loss_dict["MSE"] = _LossItem(
+                    None, self._mse_loss(preds[:, i, :], targets)
+                )
+            loss_dict["ESR"] = _LossItem(None, self._esr_loss(preds[:, i, :], targets))
+            val_loss = self._get_val_loss_from_loss_dict(loss_dict)
+            val_losses.append(val_loss)
+            logs[f"val_loss_packed_{i}"] = val_loss
+            logs[f"ESR_packed_{i}"] = loss_dict["ESR"].value
+            if "MSE" in loss_dict:
+                logs[f"MSE_packed_{i}"] = loss_dict["MSE"].value
+
+        loss_keys = sorted({key for loss_dict in loss_dicts for key in loss_dict})
+        for key in loss_keys:
+            values = [
+                loss_dict[key].value for loss_dict in loss_dicts if key in loss_dict
+            ]
+            if values:
+                logs[key] = sum(values)
+        logs["ESR"] = sum(loss_dict["ESR"].value for loss_dict in loss_dicts)
+        logs["val_loss"] = sum(val_losses)
+        self.log_dict(logs)
+        return logs["val_loss"]
+
+    def optimizer_step(self, *args, **kwargs):
+        out = super().optimizer_step(*args, **kwargs)
+        self.net.apply_mask()
+        return out
+
+    def _shared_step(
+        self, batch
+    ) -> _Tuple[_torch.Tensor, _torch.Tensor, _List[_Dict[str, _LossItem]]]:
+        args, targets = batch[:-1], batch[-1]
+        preds = self(*args, pad_start=False)
+        if preds.ndim != 3:
+            raise RuntimeError(
+                f"PackedWaveNet must return (B, P, L), got shape {tuple(preds.shape)}"
+            )
+        return (
+            preds,
+            targets,
+            [
+                self._get_loss_dict(preds[:, i, :], targets)
+                for i in range(preds.shape[1])
+            ],
+        )
+
+    def _get_val_loss_from_loss_dict(
+        self, loss_dict: _Dict[str, _LossItem]
+    ) -> _torch.Tensor:
+        val_loss_type = self._loss_config.val_loss
+        key = (
+            val_loss_type
+            if isinstance(val_loss_type, str)
+            else val_loss_type.value.upper()
+        )
+        if key not in loss_dict:
+            raise RuntimeError(f"Undefined validation loss routine for {val_loss_type}")
+        return loss_dict[key].value
+
+
+class PackedMaskCallback(_pl.Callback):
+    """Keep packed off-block weights exactly zero after optimizer updates."""
+
+    def on_before_zero_grad(self, trainer, pl_module, optimizer) -> None:
+        if isinstance(getattr(pl_module, "net", None), _PackedWaveNet):
+            pl_module.net.apply_mask()
+
+
+class PackedBestCheckpoint(_pl.Callback):
+    """
+    Track one best full Lightning checkpoint for each packed submodel.
+    """
+
+    def __init__(self, dirpath: _Optional[_Path] = None):
+        super().__init__()
+        self.dirpath = None if dirpath is None else _Path(dirpath)
+        self.best: _Dict[int, _Dict[str, _Any]] = {}
+
+    @property
+    def checkpoint_paths(self) -> _List[_Optional[str]]:
+        if not self.best:
+            return []
+        n = max(self.best) + 1
+        return [self.best.get(i, {}).get("checkpoint_path") for i in range(n)]
+
+    def on_validation_end(self, trainer, pl_module) -> None:
+        if not isinstance(getattr(pl_module, "net", None), _PackedWaveNet):
+            return
+        if getattr(trainer, "sanity_checking", False):
+            return
+        pl_module.net.apply_mask()
+        dirpath = self.dirpath or _Path(trainer.default_root_dir)
+        dirpath.mkdir(parents=True, exist_ok=True)
+        for i, name in enumerate(pl_module.net.submodel_names):
+            key = f"val_loss_packed_{i}"
+            if key not in trainer.callback_metrics:
+                continue
+            metric_tensor = trainer.callback_metrics[key]
+            metric = float(metric_tensor.detach().cpu())
+            current_best = self.best.get(i, {}).get("best_metric")
+            if current_best is not None and metric >= current_best:
+                continue
+            checkpoint_path = dirpath / f"packed_best_submodel_{i}.ckpt"
+            trainer.save_checkpoint(checkpoint_path)
+            self.best[i] = {
+                "submodel_index": i,
+                "submodel_name": name,
+                "best_metric": metric,
+                "epoch": int(trainer.current_epoch),
+                "step": int(trainer.global_step),
+                "checkpoint_path": str(checkpoint_path),
+            }
+        self._write_metadata(dirpath)
+
+    def _write_metadata(self, dirpath: _Path) -> None:
+        if not self.best:
+            return
+        with open(dirpath / "packed_best.json", "w") as fp:
+            _json.dump(
+                {"submodels": [self.best[i] for i in sorted(self.best)]},
+                fp,
+                indent=4,
             )

--- a/nam_full_configs/models/wavenet_packed.json
+++ b/nam_full_configs/models/wavenet_packed.json
@@ -1,0 +1,60 @@
+{
+    "_notes": [
+        "Packed WaveNet: trains multiple compatible WaveNet channel widths in one masked model."
+    ],
+    "net": {
+        "name": "PackedWaveNet",
+        "config": {
+            "submodels": [
+                {
+                    "name": "small",
+                    "config": {
+                        "layers_configs": [
+                            {
+                                "condition_size": 1,
+                                "input_size": 1,
+                                "channels": 3,
+                                "head": {"out_channels": 1, "kernel_size": 1, "bias": true},
+                                "kernel_size": 6,
+                                "dilations": [1, 5, 29, 97, 227],
+                                "activation": "LeakyReLU"
+                            }
+                        ],
+                        "head": null,
+                        "head_scale": 0.01
+                    }
+                },
+                {
+                    "name": "large",
+                    "config": {
+                        "layers_configs": [
+                            {
+                                "condition_size": 1,
+                                "input_size": 1,
+                                "channels": 8,
+                                "head": {"out_channels": 1, "kernel_size": 1, "bias": true},
+                                "kernel_size": 6,
+                                "dilations": [1, 5, 29, 97, 227],
+                                "activation": "LeakyReLU"
+                            }
+                        ],
+                        "head": null,
+                        "head_scale": 0.01
+                    }
+                }
+            ],
+            "export": {
+                "container_max_values": "uniform"
+            }
+        }
+    },
+    "optimizer": {
+        "lr": 0.004
+    },
+    "lr_scheduler": {
+        "class": "ExponentialLR",
+        "kwargs": {
+            "gamma": 0.993
+        }
+    }
+}

--- a/tests/test_nam/test_models/test_packed_wavenet.py
+++ b/tests/test_nam/test_models/test_packed_wavenet.py
@@ -1,0 +1,350 @@
+import json as _json
+
+import pytest as _pytest
+import torch as _torch
+
+from nam.models.wavenet import PackedWaveNet as _PackedWaveNet
+from nam.models.wavenet import WaveNet as _WaveNet
+from nam.models.wavenet._packed_conv import PackedConv1dBase as _PackedConv1dBase
+
+
+def _wavenet_config(channels: int, *, dilations=None, activation="Tanh"):
+    return {
+        "layers_configs": [
+            {
+                "input_size": 1,
+                "condition_size": 1,
+                "channels": channels,
+                "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
+                "kernel_size": [2, 3],
+                "dilations": [1, 2] if dilations is None else dilations,
+                "activation": activation,
+            }
+        ],
+        "head": None,
+        "head_scale": 0.25,
+    }
+
+
+def _packed_config():
+    return {
+        "submodels": [
+            {"name": "small", "config": _wavenet_config(3)},
+            {"name": "large", "config": _wavenet_config(8)},
+        ],
+        "export": {"container_max_values": "uniform"},
+    }
+
+
+def _two_array_wavenet_config(channels_0: int, channels_1: int):
+    return {
+        "layers_configs": [
+            {
+                "input_size": 1,
+                "condition_size": 1,
+                "channels": channels_0,
+                "head": {
+                    "out_channels": channels_1,
+                    "kernel_size": 1,
+                    "bias": False,
+                },
+                "kernel_size": 2,
+                "dilations": [1],
+                "activation": "Tanh",
+            },
+            {
+                "input_size": channels_0,
+                "condition_size": 1,
+                "channels": channels_1,
+                "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
+                "kernel_size": 2,
+                "dilations": [1],
+                "activation": "Tanh",
+            },
+        ],
+        "head": None,
+        "head_scale": 0.25,
+    }
+
+
+def test_packed_wavenet_forward_shape():
+    model = _PackedWaveNet.init_from_config(_packed_config())
+    x = _torch.randn(4, model.receptive_field + 11)
+    y = model(x)
+    assert y.shape == (4, 2, x.shape[-1])
+
+
+def test_packed_wavenet_mps_fallback_stitches_time_axis():
+    """Packed fallback must stitch chunks along time, not submodels."""
+    model = _PackedWaveNet.init_from_config(_packed_config())
+    model.eval()
+    batch_size = 1
+    input_length = 65_536 + model.receptive_field + 1
+    x = _torch.linspace(-1.0, 1.0, input_length).repeat(batch_size, 1)
+
+    with _torch.no_grad():
+        y_reference = model(x, pad_start=False)
+        model._mps_65536_fallback = True
+        y_fallback = model(x, pad_start=False)
+
+    expected_length = input_length - model.receptive_field + 1
+    assert y_fallback.shape == y_reference.shape
+    assert y_fallback.shape == (batch_size, model.num_submodels, expected_length)
+    assert _torch.allclose(y_fallback, y_reference, atol=1.0e-6)
+
+
+def test_packed_wavenet_supports_compatible_multiple_layer_arrays():
+    model = _PackedWaveNet.init_from_config(
+        {
+            "submodels": [
+                {"name": "small", "config": _two_array_wavenet_config(3, 2)},
+                {"name": "large", "config": _two_array_wavenet_config(8, 4)},
+            ]
+        }
+    )
+    x = _torch.randn(4, model.receptive_field + 11)
+    assert model(x).shape == (4, 2, x.shape[-1])
+
+
+def test_packed_wavenet_rejects_mismatched_head_path_between_layer_arrays():
+    config = {
+        "submodels": [
+            {"name": "small", "config": _two_array_wavenet_config(3, 2)},
+            {"name": "large", "config": _two_array_wavenet_config(8, 4)},
+        ]
+    }
+    config["submodels"][1]["config"]["layers_configs"][0]["head"]["out_channels"] = 3
+    with _pytest.raises(ValueError, match="head channels"):
+        _PackedWaveNet.init_from_config(config)
+
+
+@_pytest.mark.parametrize(
+    "mutate,match",
+    (
+        (
+            lambda c: c["submodels"][1]["config"]["layers_configs"].append(
+                c["submodels"][1]["config"]["layers_configs"][0].copy()
+            ),
+            "same number of layer arrays",
+        ),
+        (
+            lambda c: c["submodels"][1]["config"]["layers_configs"][0].update(
+                {"dilations": [1, 4]}
+            ),
+            "dilations",
+        ),
+        (
+            lambda c: c["submodels"][1]["config"]["layers_configs"][0].update(
+                {"activation": "ReLU"}
+            ),
+            "activations",
+        ),
+        (
+            lambda c: c["submodels"][1]["config"].update({"condition_dsp": {}}),
+            "condition_dsp",
+        ),
+        (
+            lambda c: c["submodels"][1]["config"]["layers_configs"][0].update(
+                {"groups_input": 2}
+            ),
+            "grouped",
+        ),
+        (
+            lambda c: c["submodels"][1]["config"]["layers_configs"][0].update(
+                {
+                    "activation": {
+                        "name": "PairMultiply",
+                        "primary": "Tanh",
+                        "secondary": "Sigmoid",
+                    }
+                }
+            ),
+            "paired/gated",
+        ),
+    ),
+)
+def test_packed_wavenet_validation_rejects_incompatible_configs(mutate, match):
+    config = _packed_config()
+    mutate(config)
+    with _pytest.raises((ValueError, NotImplementedError), match=match):
+        _PackedWaveNet.init_from_config(config)
+
+
+def test_packed_conv_masks_invalid_weights_and_gradients():
+    model = _PackedWaveNet.init_from_config(_packed_config())
+    conv = next(m for m in model.modules() if isinstance(m, _PackedConv1dBase))
+    with _torch.no_grad():
+        conv.weight.fill_(1.0)
+    model.apply_mask()
+    conv._assert_masked()
+    x = _torch.randn(2, model.receptive_field + 8)
+    loss = model(x).sum()
+    loss.backward()
+    invalid_grad = conv.weight.grad * (1.0 - conv._weight_mask)
+    assert _torch.allclose(invalid_grad, _torch.zeros_like(invalid_grad))
+
+
+def test_packed_forward_matches_imported_ordinary_submodels():
+    ordinary = [
+        _WaveNet.init_from_config(_wavenet_config(3)),
+        _WaveNet.init_from_config(_wavenet_config(8)),
+    ]
+    packed = _PackedWaveNet.init_from_config(_packed_config())
+    for i, submodel in enumerate(ordinary):
+        packed.import_submodel(i, submodel)
+
+    x = _torch.randn(3, packed.receptive_field + 13)
+    y_packed = packed(x)
+    for i, submodel in enumerate(ordinary):
+        assert _torch.allclose(y_packed[:, i, :], submodel(x), atol=1.0e-6)
+
+
+def test_packed_extraction_matches_packed_output():
+    packed = _PackedWaveNet.init_from_config(_packed_config())
+    x = _torch.randn(3, packed.receptive_field + 13)
+    y_packed = packed(x)
+    for i in range(packed.num_submodels):
+        extracted = packed.extract_submodel(i)
+        assert _torch.allclose(extracted(x), y_packed[:, i, :], atol=1.0e-6)
+
+
+def test_packed_export_writes_slimmable_container(tmp_path):
+    model = _PackedWaveNet.init_from_config({**_packed_config(), "sample_rate": 48_000})
+    container = model.export_container(tmp_path)
+    with open(tmp_path / "model.nam", "r") as fp:
+        from_disk = _json.load(fp)
+    assert from_disk == container
+    _assert_container_contains_two_wavenets(container)
+
+
+def test_packed_export_loads_lightning_checkpoint(tmp_path):
+    from nam.train.lightning_module import PackedLightningModule as _PackedLightningModule
+
+    packed = _PackedWaveNet.init_from_config({**_packed_config(), "sample_rate": 48_000})
+    checkpoint_path = tmp_path / "lightning.ckpt"
+    _torch.save(
+        {
+            "state_dict": _PackedLightningModule(packed).state_dict(),
+            "sample_rate": 48_000,
+        },
+        checkpoint_path,
+    )
+
+    exporter = _PackedWaveNet.init_from_config(
+        {**_packed_config(), "sample_rate": 48_000}
+    )
+    container = exporter.export_container(
+        tmp_path,
+        checkpoint_paths_by_submodel=[checkpoint_path, checkpoint_path],
+    )
+
+    _assert_container_contains_two_wavenets(container)
+
+
+def test_packed_export_loads_raw_packed_state_dict_checkpoint(tmp_path):
+    packed = _PackedWaveNet.init_from_config({**_packed_config(), "sample_rate": 48_000})
+    checkpoint_path = tmp_path / "raw.ckpt"
+    _torch.save(
+        {"state_dict": packed.state_dict(), "sample_rate": 48_000},
+        checkpoint_path,
+    )
+
+    exporter = _PackedWaveNet.init_from_config(
+        {**_packed_config(), "sample_rate": 48_000}
+    )
+    container = exporter.export_container(
+        tmp_path,
+        checkpoint_paths_by_submodel=[checkpoint_path, checkpoint_path],
+    )
+
+    _assert_container_contains_two_wavenets(container)
+
+
+def test_packed_export_rejects_corrupt_checkpoint(tmp_path):
+    packed = _PackedWaveNet.init_from_config({**_packed_config(), "sample_rate": 48_000})
+    state_dict = dict(packed.state_dict())
+    key, value = state_dict.popitem()
+    state_dict[f"corrupt.{key}"] = value
+    checkpoint_path = tmp_path / "corrupt.ckpt"
+    _torch.save(
+        {"state_dict": state_dict, "sample_rate": 48_000},
+        checkpoint_path,
+    )
+
+    exporter = _PackedWaveNet.init_from_config(
+        {**_packed_config(), "sample_rate": 48_000}
+    )
+    with _pytest.raises(RuntimeError) as exc_info:
+        exporter.export_container(
+            tmp_path,
+            checkpoint_paths_by_submodel=[checkpoint_path, checkpoint_path],
+        )
+    message = str(exc_info.value)
+    assert str(checkpoint_path) in message
+    assert "missing keys" in message
+    assert "unexpected keys" in message
+
+
+def _assert_container_contains_two_wavenets(container):
+    assert container["architecture"] == "SlimmableContainer"
+    assert container["weights"] == []
+    assert len(container["config"]["submodels"]) == 2
+    assert container["config"]["submodels"][-1]["max_value"] == 1.0
+    assert [
+        item["model"]["architecture"] for item in container["config"]["submodels"]
+    ] == ["WaveNet", "WaveNet"]
+
+
+def test_packed_export_uses_checkpoint_selected_for_each_submodel(tmp_path):
+    def set_parameter_values(model, value):
+        with _torch.no_grad():
+            for parameter in model.parameters():
+                parameter.fill_(value)
+        model.apply_mask()
+
+    def save_lightning_checkpoint(model, path):
+        from nam.train.lightning_module import (
+            PackedLightningModule as _PackedLightningModule,
+        )
+
+        _torch.save(
+            {
+                "state_dict": _PackedLightningModule(model).state_dict(),
+                "sample_rate": model.sample_rate,
+            },
+            path,
+        )
+
+    config = {**_packed_config(), "sample_rate": 48_000}
+    base = _PackedWaveNet.init_from_config(config)
+    source_a = _PackedWaveNet.init_from_config(config)
+    source_b = _PackedWaveNet.init_from_config(config)
+    set_parameter_values(base, -3.0)
+    set_parameter_values(source_a, 1.0)
+    set_parameter_values(source_b, 2.0)
+
+    checkpoint_a = tmp_path / "source_a.ckpt"
+    checkpoint_b = tmp_path / "source_b.ckpt"
+    save_lightning_checkpoint(source_a, checkpoint_a)
+    save_lightning_checkpoint(source_b, checkpoint_b)
+
+    container = base.export_container(
+        tmp_path,
+        checkpoint_paths_by_submodel=[str(checkpoint_a), str(checkpoint_b)],
+    )
+
+    exported_submodels = [item["model"] for item in container["config"]["submodels"]]
+    expected_submodel_0 = source_a.extract_submodel(0)._get_export_dict()
+    expected_submodel_1 = source_b.extract_submodel(1)._get_export_dict()
+
+    assert container["architecture"] == "SlimmableContainer"
+    assert [model["architecture"] for model in exported_submodels] == [
+        "WaveNet",
+        "WaveNet",
+    ]
+    assert exported_submodels[0]["weights"] == _pytest.approx(
+        expected_submodel_0["weights"]
+    )
+    assert exported_submodels[1]["weights"] == _pytest.approx(
+        expected_submodel_1["weights"]
+    )

--- a/tests/test_nam/test_train/test_full_packed.py
+++ b/tests/test_nam/test_train/test_full_packed.py
@@ -1,0 +1,137 @@
+import json
+
+import numpy as np
+
+from nam.data import np_to_wav as _np_to_wav
+from nam.train import full as _full
+
+
+_NUM_SAMPLES = 128
+_NUM_VALIDATION_SAMPLES = 32
+_NY = 8
+_RATE = 48_000
+
+
+def _write_wav_pair(tmp_path):
+    t = np.arange(_NUM_SAMPLES, dtype=np.float64) / _RATE
+    x = 0.10 * np.sin(2.0 * np.pi * 220.0 * t)
+    y = 0.50 * x + 0.02 * np.sin(2.0 * np.pi * 440.0 * t)
+    x_path = tmp_path / "input.wav"
+    y_path = tmp_path / "output.wav"
+    _np_to_wav(x, x_path, rate=_RATE)
+    _np_to_wav(y, y_path, rate=_RATE)
+    return x_path, y_path
+
+
+def _data_config(x_path, y_path):
+    return {
+        "common": {
+            "x_path": str(x_path),
+            "y_path": str(y_path),
+            "delay": 0,
+            "require_input_pre_silence": None,
+        },
+        "train": {
+            "stop_samples": -_NUM_VALIDATION_SAMPLES,
+            "ny": _NY,
+        },
+        "validation": {
+            "start_samples": -_NUM_VALIDATION_SAMPLES,
+            "ny": None,
+        },
+    }
+
+
+def _wavenet_config(channels):
+    return {
+        "layers_configs": [
+            {
+                "input_size": 1,
+                "condition_size": 1,
+                "channels": channels,
+                "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
+                "kernel_size": 2,
+                "dilations": [1],
+                "activation": "Tanh",
+            }
+        ],
+        "head": None,
+        "head_scale": 0.25,
+    }
+
+
+def _model_config():
+    return {
+        "net": {
+            "name": "PackedWaveNet",
+            "config": {
+                "submodels": [
+                    {"name": "small", "config": _wavenet_config(2)},
+                    {"name": "large", "config": _wavenet_config(4)},
+                ],
+            },
+        },
+        "optimizer": {"lr": 0.001},
+        "lr_scheduler": None,
+        "loss": {"val_loss": "mse"},
+    }
+
+
+def _learning_config():
+    return {
+        "train_dataloader": {
+            "batch_size": 2,
+            "shuffle": False,
+            "drop_last": False,
+            "num_workers": 0,
+        },
+        "val_dataloader": {
+            "batch_size": 1,
+            "num_workers": 0,
+        },
+        "trainer": {
+            "accelerator": "cpu",
+            "devices": 1,
+            "max_epochs": 1,
+            "limit_train_batches": 1,
+            "limit_val_batches": 1,
+            "num_sanity_val_steps": 0,
+            "enable_progress_bar": False,
+            "enable_model_summary": False,
+            "logger": False,
+        },
+        "trainer_fit_kwargs": {},
+    }
+
+
+def test_full_main_exports_packed_slimmable_container(tmp_path):
+    x_path, y_path = _write_wav_pair(tmp_path)
+    outdir = tmp_path / "out"
+    outdir.mkdir()
+
+    _full.main(
+        _data_config(x_path, y_path),
+        _model_config(),
+        _learning_config(),
+        outdir,
+        no_show=True,
+        make_plots=False,
+    )
+
+    model_path = outdir / "model.nam"
+    assert model_path.exists()
+    with open(model_path, "r") as fp:
+        model = json.load(fp)
+
+    assert model["architecture"] == "SlimmableContainer"
+    assert model["weights"] == []
+    submodels = model["config"]["submodels"]
+    assert len(submodels) == 2
+    assert [entry["model"]["architecture"] for entry in submodels] == [
+        "WaveNet",
+        "WaveNet",
+    ]
+
+    assert (outdir / "packed_best.json").exists()
+    for i in range(2):
+        assert (outdir / f"packed_best_submodel_{i}.ckpt").exists()

--- a/tests/test_nam/test_train/test_lightning_module.py
+++ b/tests/test_nam/test_train/test_lightning_module.py
@@ -10,6 +10,7 @@ import torch as _torch
 from nam._dependencies.auraloss.freq import (
     MultiResolutionSTFTLoss as _MultiResolutionSTFTLoss,
 )
+from nam.models.wavenet import PackedWaveNet as _PackedWaveNet
 from nam.train import lightning_module as _lightning_module
 
 from ..test_models.test_base import MockBaseNet as _MockBaseNet
@@ -140,6 +141,101 @@ def test_custom_losses_init():
     assert loss.ndim == 0
     # Anc coincidentally for this test:
     assert loss.item() == _torch.nn.MSELoss()(preds, targets)
+
+
+def _packed_wavenet():
+    def cfg(channels):
+        return {
+            "layers_configs": [
+                {
+                    "input_size": 1,
+                    "condition_size": 1,
+                    "channels": channels,
+                    "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
+                    "kernel_size": 2,
+                    "dilations": [1],
+                    "activation": "Tanh",
+                }
+            ],
+            "head": None,
+            "head_scale": 1.0,
+        }
+
+    return _PackedWaveNet.init_from_config(
+        {
+            "submodels": [
+                {"name": "small", "config": cfg(2)},
+                {"name": "large", "config": cfg(4)},
+            ]
+        }
+    )
+
+
+def test_packed_lightning_training_step_sums_submodel_losses():
+    net = _packed_wavenet()
+    module = _lightning_module.PackedLightningModule(
+        net,
+        loss_config=_lightning_module.LossConfig(mse_weight=1.0),
+    )
+    x = _torch.randn(3, net.receptive_field + 8)
+    targets = _torch.randn(3, x.shape[-1] - net.receptive_field + 1)
+    loss = module.training_step((x, targets), 0)
+    preds = module.net(x, pad_start=False)
+    expected = sum(
+        module._get_loss_dict(preds[:, i, :], targets)["MSE"].value
+        for i in range(preds.shape[1])
+    )
+    assert _torch.allclose(loss, expected)
+
+
+def test_packed_lightning_validation_logs_per_submodel_and_aggregate():
+    net = _packed_wavenet()
+    module = _lightning_module.PackedLightningModule(
+        net,
+        loss_config=_lightning_module.LossConfig(
+            val_loss=_lightning_module.ValidationLoss.MSE
+        ),
+    )
+    captured = {}
+    module.log_dict = lambda logs: captured.update(logs)
+    x = _torch.randn(3, net.receptive_field + 8)
+    targets = _torch.randn(3, x.shape[-1] - net.receptive_field + 1)
+    val_loss = module.validation_step((x, targets), 0)
+    assert "val_loss" in captured
+    assert "val_loss_packed_0" in captured
+    assert "val_loss_packed_1" in captured
+    assert "ESR_packed_0" in captured
+    assert "MSE_packed_1" in captured
+    assert _torch.allclose(
+        val_loss, captured["val_loss_packed_0"] + captured["val_loss_packed_1"]
+    )
+
+
+def test_packed_best_checkpoint_records_distinct_checkpoints(tmp_path):
+    module = _lightning_module.PackedLightningModule(_packed_wavenet())
+    callback = _lightning_module.PackedBestCheckpoint(dirpath=tmp_path)
+
+    class Trainer:
+        default_root_dir = tmp_path
+        current_epoch = 3
+        global_step = 17
+        callback_metrics = {
+            "val_loss_packed_0": _torch.tensor(0.5),
+            "val_loss_packed_1": _torch.tensor(0.25),
+        }
+
+        def save_checkpoint(self, path):
+            path.write_text("checkpoint")
+
+    trainer = Trainer()
+    callback.on_validation_end(trainer, module)
+    assert (tmp_path / "packed_best_submodel_0.ckpt").exists()
+    assert (tmp_path / "packed_best_submodel_1.ckpt").exists()
+    assert (tmp_path / "packed_best.json").exists()
+    assert callback.checkpoint_paths == [
+        str(tmp_path / "packed_best_submodel_0.ckpt"),
+        str(tmp_path / "packed_best_submodel_1.ckpt"),
+    ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Packed WaveNet Training

## Summary

Adds packed WaveNet training: multiple compatible WaveNet submodels can now be trained inside one larger masked WaveNet, with one prediction per packed submodel and a summed per-submodel training objective. Final export extracts ordinary `WaveNet` models from the packed training graph and writes them into a `SlimmableContainer` `.nam` file.

This is intended for cases where several related WaveNet models share the same temporal architecture but differ in channel counts.

## What Changed

- Added a registered `PackedWaveNet` model type.
- Added packed WaveNet config validation and layout construction.
- Added packed masked convolution modules for block-diagonal submodel paths.
- Extended WaveNet layer-array construction to support packed convolution factories while keeping packed and slimmable modes mutually exclusive.
- Added `PackedLightningModule` for packed loss/validation behavior.
- Added packed-specific callbacks:
  - `PackedMaskCallback` keeps off-block weights exactly zero after optimizer steps.
  - `PackedBestCheckpoint` tracks best full packed checkpoints per submodel.
- Added packed export support that builds a `SlimmableContainer` from extracted ordinary `WaveNet` submodels.
- Hardened packed checkpoint loading so final export fails loudly on malformed or mismatched checkpoint state dicts.
- Fixed the long-input MPS fallback path for packed outputs by adding an overridable fallback concat dimension.
- Added a public packed config example: `nam_full_configs/models/wavenet_packed.json`.
- Added user-facing packed training documentation under the full-training tutorials.
- Added task-spec markdowns under `docs/packed-training-pr-tasks/` for the review/follow-up work completed on this branch.

## Export Behavior

Packed training exports `model.nam` with:

- `architecture: "SlimmableContainer"`
- `weights: []`
- `config.submodels[*].model` containing complete ordinary `WaveNet` model dicts

The packed training graph itself is not the runtime format. If per-submodel best checkpoints are available, export uses the checkpoint selected for each submodel before extraction.

## Current Scope And Limits

Packed training currently supports compatible mono WaveNet submodels with matching temporal structure. Channel counts may differ.

Unsupported for packed training in this initial implementation:

- `condition_dsp`
- top-level WaveNet heads
- FiLM
- grouped convolutions
- grouped `layer1x1` or `head1x1`
- paired/gated activations
- packed plus slimmable configuration in the same submodel
- multi-channel input
- multi-channel conditioning audio
- multi-channel output beyond one output channel per packed submodel

## Tests Added

- Packed forward shape and multi-layer-array compatibility.
- Packed config validation errors for incompatible submodels.
- Packed mask enforcement for invalid weights and gradients.
- Packed forward/extraction equivalence against ordinary WaveNet submodels.
- Packed `SlimmableContainer` export.
- Packed export from Lightning-style checkpoints.
- Packed export from raw packed state-dict checkpoints.
- Corrupt packed checkpoint rejection.
- Per-submodel checkpoint selection during container export.
- Packed MPS fallback stitching along the time axis.
- Packed `nam.train.full.main()` smoke test through final `SlimmableContainer` export.
- Packed Lightning training/validation/callback behavior.

## Validation

Environment:

```console
conda run -n stew python --version
# Python 3.13.11
```

Focused tests after merging `main`:

```console
conda run -n stew python -m pytest \
  tests/test_nam/test_models/test_base.py \
  tests/test_nam/test_models/test_wavenet.py \
  tests/test_nam/test_models/test_packed_wavenet.py \
  tests/test_nam/test_train/test_full_packed.py -q
```

Result:

```text
131 passed, 1 skipped
```

Full suite after merging `main`:

```console
conda run -n stew python -m pytest
```

Result:

```text
349 passed, 22 skipped, 26 warnings
```

Diff check:

```console
git diff --check main...HEAD
```

Result: clean.

## Notes For Review

- The implementation intentionally reuses the existing internal WaveNet path instead of forking a separate packed WaveNet implementation.
- Packed convolutions still use dense weight tensors with explicit masks. This keeps import/export and checkpoint compatibility straightforward, but it means registered parameter count can exceed the effective per-submodel parameter count.
- Final export is deliberately conservative: malformed checkpoint state dicts now raise errors rather than being loaded with `strict=False`.
- The MPS fallback change keeps the default BaseNet concat axis as `1` and overrides it only for `PackedWaveNet`, where time is the final axis in `(batch, submodel, time)`.

