### PR TITLE
Update simplified trainers to use A2

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include nam/models/_resources/loudness_input.wav
+include nam/train/_resources/config_model_packed.json

--- a/docs/source/tutorials/colab.rst
+++ b/docs/source/tutorials/colab.rst
@@ -69,14 +69,13 @@ button and everything will finish in about 10 minutes.
 
 .. image:: media/colab/1-click-train.png
 
-However, there are a lot of options below that you can use to tweak the training
-that are worth getting familiar with.
+The Colab trainer uses NAM's fixed packed WaveNet configuration. There are a
+few options below that you can use to control the run.
 
 Here are the options explained:
 
 **Training Parameters**
 * ``epochs``: Number of training epochs. NAM uses validation-set checkpointing and automatically restores the best checkpoint from the entire run after training completes.
-* ``architecture``: Selects the network size/complexity (listed in order of decreasing CPU usage and accuracy). Defaults to the standard architecture.
 * ``latency_samples``: How far the output lags the input due to round-trip latency during reamping, in samples. If not ``"auto"``, it must be an integer value for the measured latency.
 * ``ignore_checks``: Skips data-quality checks.
 

--- a/docs/source/tutorials/full.rst
+++ b/docs/source/tutorials/full.rst
@@ -51,10 +51,12 @@ and editing it to point to your audio files like this:
     how much latency there is, it's usually a good idea to add a few samples 
     just so that the model doesn't need to "predict the future"!
 
-Next, copy to e.g. ``model.json`` a file for whicever model architecture you want to
-use (e.g. 
-`nam_full_configs/models/wavenet.json <https://github.com/sdatkinson/neural-amp-modeler/blob/main/nam_full_configs/models/wavenet.json>`_ 
-for the standard WaveNet from the simplified trainers), and copy to e.g. 
+Next, copy to e.g. ``model.json`` a file for whichever model architecture you want to
+use (e.g.
+`nam_full_configs/models/wavenet.json <https://github.com/sdatkinson/neural-amp-modeler/blob/main/nam_full_configs/models/wavenet.json>`_
+for a standalone WaveNet, or
+`nam_full_configs/models/wavenet_packed.json <https://github.com/sdatkinson/neural-amp-modeler/blob/main/nam_full_configs/models/wavenet_packed.json>`_
+for an example packed WaveNet), and copy to e.g.
 ``learning.json`` the contents of 
 `nam_full_configs/learning/demo.json <https://github.com/sdatkinson/neural-amp-modeler/blob/main/nam_full_configs/learning/demo.json>`_
 (for a quick demo run) or

--- a/docs/source/tutorials/packed-training.rst
+++ b/docs/source/tutorials/packed-training.rst
@@ -6,6 +6,10 @@ masked WaveNet. Each submodel makes its own prediction for the same target
 audio, and training computes the loss for each prediction against that target
 before summing the losses.
 
+The simplified GUI and Colab trainers use a fixed packed WaveNet configuration
+automatically. This page covers configuring packed training directly with the
+full trainer.
+
 Packed training is a slimmable NAM training method, but it is different from
 the channel-slicing slimmable WaveNet method. Packed training keeps the
 submodels independent during training by using block-diagonal masked weights.

--- a/nam/train/_resources/__init__.py
+++ b/nam/train/_resources/__init__.py
@@ -1,0 +1,1 @@
+"""Package resources for the simplified trainer."""

--- a/nam/train/_resources/config_model_packed.json
+++ b/nam/train/_resources/config_model_packed.json
@@ -1,0 +1,166 @@
+{
+    "net": {
+        "name": "PackedWaveNet",
+        "config": {
+            "submodels": [
+                {
+                    "name": "channels_3",
+                    "config": {
+                        "layers_configs": [
+                            {
+                                "input_size": 1,
+                                "condition_size": 1,
+                                "channels": 3,
+                                "kernel_sizes": [
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    15,
+                                    15,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6
+                                ],
+                                "dilations": [
+                                    1,
+                                    3,
+                                    7,
+                                    17,
+                                    41,
+                                    101,
+                                    239,
+                                    1,
+                                    3,
+                                    7,
+                                    17,
+                                    41,
+                                    101,
+                                    239,
+                                    1,
+                                    13,
+                                    1,
+                                    3,
+                                    7,
+                                    17,
+                                    41,
+                                    101,
+                                    239
+                                ],
+                                "activation": "LeakyReLU",
+                                "gated": false,
+                                "head": {
+                                    "out_channels": 1,
+                                    "kernel_size": 16,
+                                    "bias": true
+                                }
+                            }
+                        ],
+                        "head_scale": 0.01
+                    }
+                },
+                {
+                    "name": "channels_8",
+                    "config": {
+                        "layers_configs": [
+                            {
+                                "input_size": 1,
+                                "condition_size": 1,
+                                "channels": 8,
+                                "kernel_sizes": [
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    15,
+                                    15,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6
+                                ],
+                                "dilations": [
+                                    1,
+                                    3,
+                                    7,
+                                    17,
+                                    41,
+                                    101,
+                                    239,
+                                    1,
+                                    3,
+                                    7,
+                                    17,
+                                    41,
+                                    101,
+                                    239,
+                                    1,
+                                    13,
+                                    1,
+                                    3,
+                                    7,
+                                    17,
+                                    41,
+                                    101,
+                                    239
+                                ],
+                                "activation": "LeakyReLU",
+                                "gated": false,
+                                "head": {
+                                    "out_channels": 1,
+                                    "kernel_size": 16,
+                                    "bias": true
+                                }
+                            }
+                        ],
+                        "head_scale": 0.01
+                    }
+                }
+            ],
+            "export": {
+                "container_max_values": "uniform"
+            }
+        }
+    },
+    "loss": {
+        "val_loss": "esr",
+        "mrstft_weight": 0.0005
+    },
+    "optimizer": {
+        "lr": 0.004,
+        "weight_decay": 3.17e-07
+    },
+    "lr_scheduler": {
+        "class": "ExponentialLR",
+        "kwargs": {
+            "gamma": 0.994
+        }
+    }
+}

--- a/nam/train/colab.py
+++ b/nam/train/colab.py
@@ -91,23 +91,14 @@ def _get_valid_export_directory():
 def run(
     epochs: int = 100,
     delay: _Optional[int] = None,
-    model_type: str = "WaveNet",
-    architecture: str = "standard",
-    lr: float = 0.004,
-    lr_decay: float = 0.007,
     seed: _Optional[int] = 0,
     user_metadata: _Optional[_UserMetadata] = None,
     ignore_checks: bool = False,
-    fit_mrstft: bool = True,
 ):
     """
     :param epochs: How many epochs we'll train for.
     :param delay: How far the output lags the input due to round-trip latency during
         reamping, in samples.
-    :param model_type: The type of model to train.
-    :param architecture: The architecture hyperparameters to use
-    :param lr: The initial learning rate
-    :param lr_decay: The amount by which the learning rate decays each epoch
     :param seed: RNG seed for reproducibility.
     :param user_metadata: User-specified metadata to include in the .nam file.
     :param ignore_checks: Ignores the data quality checks and YOLOs it
@@ -121,14 +112,9 @@ def run(
         train_path=_TRAIN_PATH,
         epochs=epochs,
         latency=delay,
-        model_type=model_type,
-        architecture=architecture,
-        lr=lr,
-        lr_decay=lr_decay,
         seed=seed,
         local=False,
         ignore_checks=ignore_checks,
-        fit_mrstft=fit_mrstft,
     )
     model = train_output.model
     training_metadata = train_output.metadata

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -9,9 +9,10 @@ Used by the GUI and Colab trainers.
 """
 
 import hashlib as _hashlib
+import importlib.resources as _resources
+import json as _json
 import tkinter as _tk
 from copy import deepcopy as _deepcopy
-from enum import Enum as _Enum
 from functools import partial as _partial
 from pathlib import Path as _Path
 from time import time as _time
@@ -46,18 +47,14 @@ from . import metadata as _metadata
 from ._version import PROTEUS_VERSION as _PROTEUS_VERSION
 from ._version import Version as _Version
 from .lightning_module import LightningModule as _LightningModule
+from .lightning_module import PackedBestCheckpoint as _PackedBestCheckpoint
+from .lightning_module import PackedLightningModule as _PackedLightningModule
+from .lightning_module import PackedMaskCallback as _PackedMaskCallback
 
 # Training using the simplified trainers in NAM is done at 48k.
 STANDARD_SAMPLE_RATE = 48_000.0
 # Default number of output samples per datum.
 _NY_DEFAULT = 8192
-
-
-class Architecture(_Enum):
-    STANDARD = "standard"
-    LITE = "lite"
-    FEATHER = "feather"
-    NANO = "nano"
 
 
 class _InputValidationError(ValueError):
@@ -599,35 +596,6 @@ def _analyze_latency(
     return _metadata.Latency(manual=user_latency, calibration=calibration_output)
 
 
-def get_lstm_config(architecture):
-    return {
-        Architecture.STANDARD: {
-            "num_layers": 1,
-            "hidden_size": 24,
-            "train_burn_in": 4096,
-            "train_truncate": 512,
-        },
-        Architecture.LITE: {
-            "num_layers": 2,
-            "hidden_size": 8,
-            "train_burn_in": 4096,
-            "train_truncate": 512,
-        },
-        Architecture.FEATHER: {
-            "num_layers": 1,
-            "hidden_size": 16,
-            "train_burn_in": 4096,
-            "train_truncate": 512,
-        },
-        Architecture.NANO: {
-            "num_layers": 1,
-            "hidden_size": 12,
-            "train_burn_in": 4096,
-            "train_truncate": 512,
-        },
-    }[architecture]
-
-
 def _check_v1(*args, **kwargs) -> _metadata.DataChecks:
     return _metadata.DataChecks(version=1, passed=True)
 
@@ -839,107 +807,6 @@ def _check_data(
     return out
 
 
-def get_wavenet_config(architecture):
-    return {
-        Architecture.STANDARD: {
-            "layers_configs": [
-                {
-                    "input_size": 1,
-                    "condition_size": 1,
-                    "channels": 16,
-                    "head": {"out_channels": 8, "kernel_size": 1, "bias": False},
-                    "kernel_size": 3,
-                    "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
-                    "activation": "Tanh",
-                },
-                {
-                    "condition_size": 1,
-                    "input_size": 16,
-                    "channels": 8,
-                    "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
-                    "kernel_size": 3,
-                    "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
-                    "activation": "Tanh",
-                },
-            ],
-            "head_scale": 0.02,
-        },
-        Architecture.LITE: {
-            "layers_configs": [
-                {
-                    "input_size": 1,
-                    "condition_size": 1,
-                    "channels": 12,
-                    "head": {"out_channels": 6, "kernel_size": 1, "bias": False},
-                    "kernel_size": 3,
-                    "dilations": [1, 2, 4, 8, 16, 32, 64],
-                    "activation": "Tanh",
-                },
-                {
-                    "condition_size": 1,
-                    "input_size": 12,
-                    "channels": 6,
-                    "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
-                    "kernel_size": 3,
-                    "dilations": [128, 256, 512, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
-                    "activation": "Tanh",
-                },
-            ],
-            "head_scale": 0.02,
-        },
-        Architecture.FEATHER: {
-            "layers_configs": [
-                {
-                    "input_size": 1,
-                    "condition_size": 1,
-                    "channels": 8,
-                    "head": {"out_channels": 4, "kernel_size": 1, "bias": False},
-                    "kernel_size": 3,
-                    "dilations": [1, 2, 4, 8, 16, 32, 64],
-                    "activation": "Tanh",
-                },
-                {
-                    "condition_size": 1,
-                    "input_size": 8,
-                    "channels": 4,
-                    "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
-                    "kernel_size": 3,
-                    "dilations": [128, 256, 512, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
-                    "activation": "Tanh",
-                },
-            ],
-            "head_scale": 0.02,
-        },
-        Architecture.NANO: {
-            "layers_configs": [
-                {
-                    "input_size": 1,
-                    "condition_size": 1,
-                    "channels": 4,
-                    "head": {"out_channels": 2, "kernel_size": 1, "bias": False},
-                    "kernel_size": 3,
-                    "dilations": [1, 2, 4, 8, 16, 32, 64],
-                    "activation": "Tanh",
-                },
-                {
-                    "condition_size": 1,
-                    "input_size": 4,
-                    "channels": 2,
-                    "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
-                    "kernel_size": 3,
-                    "dilations": [128, 256, 512, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
-                    "activation": "Tanh",
-                },
-            ],
-            "head_scale": 0.02,
-        },
-    }[architecture]
-
-
-_CAB_MRSTFT_PRE_EMPH_WEIGHT = 2.0e-4
-_CAB_MRSTFT_PRE_EMPH_COEF = 0.85
-
-
 def _get_data_config(
     input_version: _Version,
     input_path: _Path,
@@ -1008,19 +875,30 @@ def _get_data_config(
     return data_config
 
 
+def _get_packed_model_config() -> dict:
+    resource = _resources.files("nam.train._resources").joinpath(
+        "config_model_packed.json"
+    )
+    with resource.open() as fp:
+        return _deepcopy(_json.load(fp))
+
+
+def _get_lightning_module_cls(model_config: _Dict):
+    return (
+        _PackedLightningModule
+        if model_config["net"]["name"] == "PackedWaveNet"
+        else _LightningModule
+    )
+
+
 def _get_configs(
     input_version: _Version,
     input_path: str,
     output_path: str,
     latency: int,
     epochs: int,
-    model_type: str,
-    architecture: Architecture,
     ny: int,
-    lr: float,
-    lr_decay: float,
     batch_size: int,
-    fit_mrstft: bool,
 ):
     data_config = _get_data_config(
         input_version=input_version,
@@ -1029,40 +907,7 @@ def _get_configs(
         ny=ny,
         latency=latency,
     )
-
-    if model_type == "WaveNet":
-        model_config = {
-            "net": {
-                "name": "WaveNet",
-                # This should do decently. If you really want a nice model, try turning up
-                # "channels" in the first block and "input_size" in the second from 12 to 16.
-                "config": get_wavenet_config(architecture),
-            },
-            "loss": {"val_loss": "esr"},
-            "optimizer": {"lr": lr},
-            "lr_scheduler": {
-                "class": "ExponentialLR",
-                "kwargs": {"gamma": 1.0 - lr_decay},
-            },
-        }
-    else:
-        model_config = {
-            "net": {
-                "name": "LSTM",
-                "config": get_lstm_config(architecture),
-            },
-            "loss": {
-                "val_loss": "mse",
-                "mask_first": 4096,
-                "pre_emph_weight": 1.0,
-                "pre_emph_coef": 0.85,
-            },
-            "optimizer": {"lr": 0.01},
-            "lr_scheduler": {"class": "ExponentialLR", "kwargs": {"gamma": 0.995}},
-        }
-    if fit_mrstft:
-        model_config["loss"]["pre_emph_mrstft_weight"] = _CAB_MRSTFT_PRE_EMPH_WEIGHT
-        model_config["loss"]["pre_emph_mrstft_coef"] = _CAB_MRSTFT_PRE_EMPH_COEF
+    model_config = _get_packed_model_config()
 
     if _torch.cuda.is_available():
         device_config = {"accelerator": "gpu", "devices": 1}
@@ -1108,6 +953,18 @@ def _esr(pred: _torch.Tensor, target: _torch.Tensor) -> float:
     )
 
 
+def _esr_comment(esr: float) -> str:
+    if esr < 0.01:
+        return "Great!"
+    if esr < 0.035:
+        return "Not bad!"
+    if esr < 0.1:
+        return "...This *might* sound ok!"
+    if esr < 0.3:
+        return "...This probably won't sound great :("
+    return "...Something seems to have gone wrong."
+
+
 def _plot(
     model,
     ds,
@@ -1120,28 +977,61 @@ def _plot(
     :return: The ESR
     """
     print("Plotting a comparison of your model with the target output...")
+    net = getattr(model, "net", model)
+    num_submodels = getattr(net, "num_submodels", 1)
     with _torch.no_grad():
         tx = len(ds.x) / 48_000
         print(f"Run (t={tx:.2f} sec)")
         t0 = _time()
-        output = model(ds.x).flatten().cpu().numpy()
+        output = model(ds.x).cpu().numpy()
         t1 = _time()
         print(f"Took {t1 - t0:.2f} sec ({tx / (t1 - t0):.2f}x)")
 
+    if num_submodels > 1 and output.ndim == 3 and output.shape[0] == 1:
+        output = output[0]
+    if num_submodels > 1 and output.ndim != 2:
+        raise RuntimeError(
+            f"Packed model output should have shape (P, L), got {tuple(output.shape)}"
+        )
+    is_packed = output.ndim == 2 and (num_submodels > 1 or output.shape[0] > 1)
+
+    if is_packed:
+        submodel_names = getattr(net, "submodel_names", ())
+        labels = [
+            submodel_names[i] if i < len(submodel_names) else f"submodel {i}"
+            for i in range(output.shape[0])
+        ]
+        esrs = [_esr(_torch.Tensor(output_i), ds.y) for output_i in output]
+        aggregate_esr = sum(esrs)
+        for label, esr in zip(labels, esrs):
+            print(f"Error-signal ratio ({label}) = {esr:.4g}")
+        print(f"Aggregate error-signal ratio = {aggregate_esr:.4g}")
+        print(_esr_comment(aggregate_esr))
+
+        _plt.figure(figsize=(16, 5))
+        for label, output_i, esr in zip(labels, output, esrs):
+            _plt.plot(
+                output_i[window_start:window_end],
+                label=f"Prediction {label} (ESR={esr:.4g})",
+            )
+        _plt.plot(ds.y[window_start:window_end], linestyle="--", label="Target")
+        _plt.title(
+            "Aggregate ESR="
+            f"{aggregate_esr:.4g} ("
+            + ", ".join(f"{label}: {esr:.4g}" for label, esr in zip(labels, esrs))
+            + ")"
+        )
+        _plt.legend()
+        if filepath is not None:
+            _plt.savefig(filepath + ".png")
+        if not silent:
+            _plt.show()
+        return aggregate_esr
+
+    output = output.flatten()
     esr = _esr(_torch.Tensor(output), ds.y)
-    # Trying my best to put numbers to it...
-    if esr < 0.01:
-        esr_comment = "Great!"
-    elif esr < 0.035:
-        esr_comment = "Not bad!"
-    elif esr < 0.1:
-        esr_comment = "...This *might* sound ok!"
-    elif esr < 0.3:
-        esr_comment = "...This probably won't sound great :("
-    else:
-        esr_comment = "...Something seems to have gone wrong."
     print(f"Error-signal ratio = {esr:.4g}")
-    print(esr_comment)
+    print(_esr_comment(esr))
 
     _plt.figure(figsize=(16, 5))
     _plt.plot(output[window_start:window_end], label="Prediction")
@@ -1277,6 +1167,7 @@ class _ModelCheckpoint(_pl.callbacks.model_checkpoint.ModelCheckpoint):
 
 def get_callbacks(
     threshold_esr: _Optional[float],
+    packed: bool = False,
     user_metadata: _Optional[_UserMetadata] = None,
     settings_metadata: _Optional[_metadata.Settings] = None,
     data_metadata: _Optional[_metadata.Data] = None,
@@ -1299,6 +1190,8 @@ def get_callbacks(
             data_metadata=data_metadata,
         ),
     ]
+    if packed:
+        callbacks.extend([_PackedBestCheckpoint(), _PackedMaskCallback()])
     if threshold_esr is not None:
         callbacks.append(
             _ValidationStopping(monitor="ESR", stopping_threshold=threshold_esr)
@@ -1358,33 +1251,62 @@ def _get_final_latency(latency_analysis: _metadata.Latency) -> int:
     )
 
 
+def _apply_packed_best_checkpoints(
+    model: _PackedLightningModule,
+    model_config: _Dict,
+    checkpoint_paths: _Sequence[_Optional[str]],
+) -> None:
+    if not checkpoint_paths or not any(checkpoint_paths):
+        return
+    for submodel_index, checkpoint_path in enumerate(checkpoint_paths):
+        if checkpoint_path is None:
+            continue
+        if submodel_index >= model.net.num_submodels:
+            print(
+                "WARNING: Ignoring packed-best checkpoint for unknown submodel "
+                f"{submodel_index}: {checkpoint_path}"
+            )
+            continue
+        try:
+            source = _PackedLightningModule.load_from_checkpoint(
+                checkpoint_path, **_PackedLightningModule.parse_config(model_config)
+            )
+            source.cpu()
+            source.eval()
+            if source.net.sample_rate is None:
+                source.net.sample_rate = model.net.sample_rate
+            model.net.import_submodel(
+                submodel_index, source.net.extract_submodel(submodel_index)
+            )
+        except Exception as e:
+            print(
+                "WARNING: Failed to load packed-best checkpoint for submodel "
+                f"{submodel_index} from {checkpoint_path}: {e}"
+            )
+    model.net.apply_mask()
+
+
 def train(
     input_path: str,
     output_path: str,
     train_path: str,
     epochs=100,
     latency: _Optional[int] = None,
-    model_type: str = "WaveNet",
-    architecture: _Union[Architecture, str] = Architecture.STANDARD,
     batch_size: int = 16,
     ny: int = _NY_DEFAULT,
-    lr=0.004,
-    lr_decay=0.007,
     seed: _Optional[int] = 0,
     save_plot: bool = False,
     silent: bool = False,
     modelname: str = "model",
     ignore_checks: bool = False,
     local: bool = False,
-    fit_mrstft: bool = True,
-    threshold_esr: _Optional[bool] = None,
+    threshold_esr: _Optional[float] = None,
     user_metadata: _Optional[_UserMetadata] = None,
     fast_dev_run: _Union[bool, int] = False,
 ) -> _Optional[TrainOutput]:
     """
     :param input_path: Full path to input file
     :param output_path: Full path to output file
-    :param lr_decay: =1-gamma for Exponential learning rate decay.
     :param threshold_esr: Stop training if ESR is better than this. Ignore if `None`.
     :param fast_dev_run: One-step training, used for tests.
     """
@@ -1456,13 +1378,8 @@ def train(
         output_path,
         final_latency,
         epochs,
-        model_type,
-        Architecture(architecture),
         ny,
-        lr,
-        lr_decay,
         batch_size,
-        fit_mrstft,
     )
     assert (
         "fast_dev_run" not in learning_config
@@ -1474,7 +1391,9 @@ def train(
     # * Model is re-instantiated after training anyways.
     # (Hacky) solution: set sample rate in model from dataloader after second
     # instantiation from final checkpoint.
-    model = _LightningModule.init_from_config(model_config)
+    is_packed = model_config["net"]["name"] == "PackedWaveNet"
+    lightning_cls = _get_lightning_module_cls(model_config)
+    model = lightning_cls.init_from_config(model_config)
     train_dataloader, val_dataloader = _get_dataloaders(
         data_config, learning_config, model
     )
@@ -1490,14 +1409,20 @@ def train(
     # Put together the metadata that's needed in checkpoints:
     settings_metadata = _metadata.Settings(ignore_checks=ignore_checks)
     data_metadata = _metadata.Data(latency=latency_analysis, checks=data_check_output)
+    callbacks = get_callbacks(
+        threshold_esr,
+        packed=is_packed,
+        user_metadata=user_metadata,
+        settings_metadata=settings_metadata,
+        data_metadata=data_metadata,
+    )
+    packed_best_callback = next(
+        (c for c in callbacks if isinstance(c, _PackedBestCheckpoint)),
+        None,
+    )
 
     trainer = _pl.Trainer(
-        callbacks=get_callbacks(
-            threshold_esr,
-            user_metadata=user_metadata,
-            settings_metadata=settings_metadata,
-            data_metadata=data_metadata,
-        ),
+        callbacks=callbacks,
         default_root_dir=train_path,
         fast_dev_run=fast_dev_run,
         **learning_config["trainer"],
@@ -1514,13 +1439,17 @@ def train(
         # Go to best checkpoint
         best_checkpoint = trainer.checkpoint_callback.best_model_path
         if best_checkpoint != "":
-            model = _LightningModule.load_from_checkpoint(
+            model = lightning_cls.load_from_checkpoint(
                 trainer.checkpoint_callback.best_model_path,
-                **_LightningModule.parse_config(model_config),
+                **lightning_cls.parse_config(model_config),
             )
         model.cpu()
         model.eval()
         model.net.sample_rate = sample_rate  # Hack, part 2
+        if is_packed and packed_best_callback is not None:
+            _apply_packed_best_checkpoints(
+                model, model_config, packed_best_callback.checkpoint_paths
+            )
 
         def window_kwargs(version: _Version):
             if version.major == 1:
@@ -1721,9 +1650,9 @@ def validate_data(
         ny=num_output_samples_per_datum,
         latency=final_latency,
     )
-    # HACK this should depend on the model that's going to be used, but I think it will
-    # be unlikely to make a difference. Still, would be nice to fix.
-    data_config["common"]["nx"] = 4096
+    model_config = _get_packed_model_config()
+    model = _get_lightning_module_cls(model_config).init_from_config(model_config)
+    data_config["common"]["nx"] = model.net.receptive_field
 
     pytorch_data_split_validation_dict: _Dict[str, _PyTorchDataSplitValidation] = {}
     for split in _Split:

--- a/nam/train/gui/__init__.py
+++ b/nam/train/gui/__init__.py
@@ -70,11 +70,9 @@ except ImportError:
 if _HAVE_ACCELERATOR:
     _DEFAULT_NUM_EPOCHS = 100
     _DEFAULT_BATCH_SIZE = 16
-    _DEFAULT_LR_DECAY = 0.007
 else:
     _DEFAULT_NUM_EPOCHS = 20
     _DEFAULT_BATCH_SIZE = 1
-    _DEFAULT_LR_DECAY = 0.05
 _BUTTON_WIDTH = 20
 _BUTTON_HEIGHT = 2
 _TEXT_WIDTH = 70
@@ -128,7 +126,6 @@ def _get_latest_version_from_github() -> _Optional[_Version]:
 @_dataclass
 class AdvancedOptions(object):
     """
-    :param architecture: Which architecture to use.
     :param num_epochs: How many epochs to train for.
     :param latency: Latency between the input and output audio, in samples.
         None means we don't know and it has to be calibrated.
@@ -137,7 +134,6 @@ class AdvancedOptions(object):
         stop.
     """
 
-    architecture: _core.Architecture
     num_epochs: int
     latency: _Optional[int]
     ignore_checks: bool
@@ -538,13 +534,11 @@ class GUI(object):
         self._frame_advanced_options.pack(side=_tk.BOTTOM, anchor="e")
 
         # Advanced options for training
-        default_architecture = _core.Architecture.STANDARD
         self.advanced_options = AdvancedOptions(
-            default_architecture,
-            _DEFAULT_NUM_EPOCHS,
-            _DEFAULT_DELAY,
-            _DEFAULT_IGNORE_CHECKS,
-            _DEFAULT_THRESHOLD_ESR,
+            num_epochs=_DEFAULT_NUM_EPOCHS,
+            latency=_DEFAULT_DELAY,
+            ignore_checks=_DEFAULT_IGNORE_CHECKS,
+            threshold_esr=_DEFAULT_THRESHOLD_ESR,
         )
         # Window to edit them:
 
@@ -577,23 +571,9 @@ class GUI(object):
         Get any additional kwargs to provide to `core.train`
         """
         return {
-            "lr": 0.004,
-            "lr_decay": _DEFAULT_LR_DECAY,
             "batch_size": _DEFAULT_BATCH_SIZE,
             "seed": 0,
         }
-
-    def get_mrstft_fit(self) -> bool:
-        """
-        Use a pre-emphasized multi-resolution shot-time Fourier transform loss during
-        training.
-
-        This improves agreement in the high frequencies, usually with a minimal loss in
-        ESR.
-        """
-        # Leave this as a public method to anticipate an extension to make it
-        # changeable.
-        return True
 
     def _check_button_states(self):
         """
@@ -730,7 +710,6 @@ class GUI(object):
 
         # Advanced options:
         num_epochs = self.advanced_options.num_epochs
-        architecture = self.advanced_options.architecture
         user_latency = self.advanced_options.latency
         file_list = self._widgets[_GUIWidgets.OUTPUT_PATH].val
         threshold_esr = self.advanced_options.threshold_esr
@@ -749,13 +728,11 @@ class GUI(object):
                 self._widgets[_GUIWidgets.TRAINING_DESTINATION].val,
                 epochs=num_epochs,
                 latency=user_latency,
-                architecture=architecture,
                 silent=self._checkboxes[_CheckboxKeys.SILENT_TRAINING].variable.get(),
                 save_plot=self._checkboxes[_CheckboxKeys.SAVE_PLOT].variable.get(),
                 modelname=basename,
                 ignore_checks=ignore_checks,
                 local=True,
-                fit_mrstft=self.get_mrstft_fit(),
                 threshold_esr=threshold_esr,
                 user_metadata=user_metadata,
                 **self.core_train_kwargs(),
@@ -1111,7 +1088,7 @@ class LabeledText(_SettingWidget):
 
 class AdvancedOptionsGUI(object):
     """
-    A window to hold advanced options (Architecture and number of epochs)
+    A window to hold advanced options.
     """
 
     def __init__(self, resume_main, parent: GUI):
@@ -1146,23 +1123,12 @@ class AdvancedOptionsGUI(object):
             except ValueError:
                 pass
 
-        # TODO could clean up more / see `.pack_options()`
-        for name in ("architecture", "num_epochs", "latency", "threshold_esr"):
+        for name in ("num_epochs", "latency", "threshold_esr"):
             safe_apply(name)
 
     def pack(self):
         # TODO things that are `_SettingWidget`s are named carefully, need to make this
         # easier to work with.
-
-        # Architecture: radio buttons
-        self._frame_architecture = _tk.Frame(self._root)
-        self._frame_architecture.pack()
-        self._architecture = LabeledOptionMenu(
-            self._frame_architecture,
-            "Architecture",
-            _core.Architecture,
-            default=self._parent.advanced_options.architecture,
-        )
 
         # Number of epochs: text box
         self._frame_epochs = _tk.Frame(self._root)

--- a/nam/train/lightning_module.py
+++ b/nam/train/lightning_module.py
@@ -609,7 +609,7 @@ class PackedBestCheckpoint(_pl.Callback):
             if current_best is not None and metric >= current_best:
                 continue
             checkpoint_path = dirpath / f"packed_best_submodel_{i}.ckpt"
-            trainer.save_checkpoint(checkpoint_path)
+            trainer.save_checkpoint(checkpoint_path, weights_only=False)
             self.best[i] = {
                 "submodel_index": i,
                 "submodel_name": name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,22 @@ local_scheme = "no-local-version"
 write_to = "nam/_version.py"
 
 [tool.setuptools]
-packages = ["nam", "nam.train", "nam.train.gui", "nam.train.gui._resources", "nam.models", "nam.models._resources" ]
+include-package-data = true
+packages = [
+    "nam",
+    "nam._dependencies",
+    "nam._dependencies.auraloss",
+    "nam.train",
+    "nam.train._resources",
+    "nam.train.gui",
+    "nam.train.gui._resources",
+    "nam.models",
+    "nam.models._resources",
+    "nam.models.wavenet",
+]
+
+[tool.setuptools.package-data]
+"nam.train._resources" = ["*.json"]
 
 [tool.pytest.ini_options]
 addopts = "-x"

--- a/tests/test_nam/test_models/test_wavenet.py
+++ b/tests/test_nam/test_models/test_wavenet.py
@@ -21,8 +21,6 @@ from nam.models.wavenet._slimmable_conv import (
     SlimmableConv1dBase as _SlimmableConv1dBase,
 )
 from nam.models.wavenet._slimmable_conv import class_set as _slimmable_class_set
-from nam.train.core import Architecture as _Architecture
-from nam.train.core import get_wavenet_config as _get_wavenet_config
 
 from .base import Base as _Base
 
@@ -36,6 +34,23 @@ _FILM_SLOTS = (
     "layer1x1_post_film",
     "head1x1_post_film",
 )
+
+
+def _tiny_wavenet_config(channels: int = 2):
+    return {
+        "layers_configs": [
+            {
+                "input_size": 1,
+                "condition_size": 1,
+                "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
+                "channels": channels,
+                "kernel_size": 2,
+                "dilations": [1, 2],
+                "activation": "Tanh",
+            }
+        ],
+        "head_scale": 1.0,
+    }
 
 
 class TestWaveNet(_Base):
@@ -71,7 +86,7 @@ class TestWaveNet(_Base):
         return C.init_from_config(config)
 
     def test_import_weights(self):
-        config = _get_wavenet_config(_Architecture.FEATHER)
+        config = _tiny_wavenet_config()
         model_1 = _WaveNet.init_from_config(config)
         model_2 = _WaveNet.init_from_config(config)
 

--- a/tests/test_nam/test_train/test_colab.py
+++ b/tests/test_nam/test_train/test_colab.py
@@ -1,0 +1,18 @@
+from nam.train import colab as _colab
+
+
+def test_colab_run_does_not_forward_removed_core_kwargs(monkeypatch):
+    monkeypatch.setattr(_colab, "_check_for_files", lambda: "input.wav")
+    captured_kwargs = {}
+
+    def fake_train(**kwargs):
+        captured_kwargs.update(kwargs)
+        return _colab._TrainOutput(model=None, metadata=None)
+
+    monkeypatch.setattr(_colab, "_train", fake_train)
+
+    _colab.run(epochs=1, delay=2, seed=None, ignore_checks=True)
+
+    removed_kwargs = {"model_type", "architecture", "lr", "lr_decay", "fit_mrstft"}
+    forwarded = removed_kwargs & captured_kwargs.keys()
+    assert not forwarded

--- a/tests/test_nam/test_train/test_core.py
+++ b/tests/test_nam/test_train/test_core.py
@@ -2,13 +2,18 @@
 # Created Date: Thursday May 18th 2023
 # Author: Steven Atkinson (steven@atkinson.mn)
 
+import inspect
+import json
 import sys
+from copy import deepcopy
+from importlib import resources
 from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
+import torch
 
 from nam.data import (
     _DEFAULT_REQUIRE_INPUT_PRE_SILENCE,
@@ -20,7 +25,7 @@ from nam.data import (
 from nam.train import core
 from nam.train import metadata as _metadata
 from nam.train._version import Version
-from nam.train.lightning_module import LightningModule
+from nam.train.lightning_module import PackedLightningModule
 
 from ...resources import (
     requires_proteus,
@@ -32,6 +37,61 @@ from ...resources import (
 )
 
 __all__ = []
+
+
+_REMOVED_SIMPLIFIED_TRAINER_KWARGS = {
+    "model_type",
+    "architecture",
+    "lr",
+    "lr_decay",
+    "fit_mrstft",
+}
+
+
+def _load_packaged_packed_model_config():
+    resource = resources.files("nam.train._resources").joinpath(
+        "config_model_packed.json"
+    )
+    with resource.open("r") as fp:
+        return json.load(fp)
+
+
+def _core_removed_kwargs_present():
+    functions = (core.train, core._get_configs)
+    return {
+        name
+        for function in functions
+        for name in inspect.signature(function).parameters
+        if name in _REMOVED_SIMPLIFIED_TRAINER_KWARGS
+    }
+
+
+def _call_get_configs_for_current_core():
+    values = {
+        "input_version": Version(3, 0, 0),
+        "input_path": "input.wav",
+        "output_path": "output.wav",
+        "latency": 0,
+        "epochs": 5,
+        "ny": 16,
+        "batch_size": 2,
+    }
+    signature = inspect.signature(core._get_configs)
+    kwargs = {
+        name: deepcopy(values[name])
+        for name in signature.parameters
+        if name in values
+    }
+    missing = [
+        name
+        for name, parameter in signature.parameters.items()
+        if parameter.default is inspect.Parameter.empty
+        and parameter.kind
+        in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        and name not in kwargs
+    ]
+    assert not missing, f"Unhandled _get_configs parameters: {missing}"
+    return core._get_configs(**kwargs)
 
 
 def _resource_path(version: Version) -> Path:
@@ -277,6 +337,80 @@ def test_v3_check_doesnt_make_figure_if_silent(mocker):
         core._check_v3(input_path, output_path, silent=True)
 
 
+def test_simplified_trainer_removed_knobs_are_absent_from_core_api():
+    present = _core_removed_kwargs_present()
+    assert not present
+
+
+def test_get_configs_uses_packaged_packed_model_config():
+    _, model_config, _ = _call_get_configs_for_current_core()
+    expected_model_config = _load_packaged_packed_model_config()
+
+    assert model_config["net"]["name"] == "PackedWaveNet"
+    assert model_config["net"] == expected_model_config["net"]
+    assert model_config["loss"] == expected_model_config["loss"]
+    assert model_config["optimizer"] == expected_model_config["optimizer"]
+    assert model_config["lr_scheduler"] == expected_model_config["lr_scheduler"]
+
+
+def test_plot_reports_and_plots_each_packed_prediction(mocker, capsys):
+    target = torch.tensor([1.0, -1.0, 2.0, -2.0])
+    predictions = torch.stack([target, 0.5 * target])
+    plot_calls = []
+
+    class FakeDataset:
+        x = torch.zeros_like(target)
+        y = target
+
+    class FakeModel:
+        class net:
+            num_submodels = 2
+            submodel_names = ("small", "large")
+
+        def __call__(self, x):
+            assert torch.equal(x, FakeDataset.x)
+            return predictions
+
+    def capture_plot(*args, **kwargs):
+        plot_calls.append((args, kwargs))
+
+    times = iter((0.0, 0.5))
+    mocker.patch.object(core, "_time", lambda: next(times))
+    mocker.patch("matplotlib.pyplot.figure")
+    mocker.patch("matplotlib.pyplot.plot", capture_plot)
+    mocker.patch("matplotlib.pyplot.title")
+    mocker.patch("matplotlib.pyplot.legend")
+    mocker.patch("matplotlib.pyplot.savefig")
+    mocker.patch("matplotlib.pyplot.show")
+
+    core._plot(FakeModel(), FakeDataset, silent=True)
+
+    stdout = capsys.readouterr().out
+    assert stdout.count("Error-signal ratio") == 2
+
+    def as_numpy(value):
+        if isinstance(value, torch.Tensor):
+            return value.detach().cpu().numpy()
+        return np.asarray(value)
+
+    prediction_plots = [
+        as_numpy(args[0])
+        for args, kwargs in plot_calls
+        if "Prediction" in kwargs.get("label", "")
+    ]
+    target_plots = [
+        as_numpy(args[0])
+        for args, kwargs in plot_calls
+        if kwargs.get("label") == "Target"
+    ]
+    assert len(prediction_plots) == 2
+    assert len(target_plots) == 1
+    np.testing.assert_allclose(prediction_plots[0], predictions[0].numpy())
+    np.testing.assert_allclose(prediction_plots[1], predictions[1].numpy())
+    for plotted_target in target_plots:
+        np.testing.assert_allclose(plotted_target, target.numpy())
+
+
 @requires_v3_0_0
 def test_end_to_end():
     """
@@ -295,7 +429,7 @@ def test_end_to_end():
             fast_dev_run=True,
         )
         # Assertions...
-        assert isinstance(train_output.model, LightningModule)
+        assert isinstance(train_output.model, PackedLightningModule)
 
 
 def test_get_callbacks():

--- a/tests/test_nam/test_train/test_gui/test_main.py
+++ b/tests/test_nam/test_train/test_gui/test_main.py
@@ -2,6 +2,7 @@
 # Created Date: Friday May 24th 2024
 # Author: Steven Atkinson (steven@atkinson.mn)
 
+import inspect
 import tkinter as tk
 
 import pytest
@@ -24,6 +25,11 @@ def test_get_current_version():
     See #516
     """
     v = gui._get_current_version()
+
+
+def test_gui_does_not_depend_on_core_architecture():
+    source = inspect.getsource(gui)
+    assert "_core.Architecture" not in source
 
 
 if __name__ == "__main__":

--- a/tests/test_nam/test_train/test_lightning_module.py
+++ b/tests/test_nam/test_train/test_lightning_module.py
@@ -224,7 +224,11 @@ def test_packed_best_checkpoint_records_distinct_checkpoints(tmp_path):
             "val_loss_packed_1": _torch.tensor(0.25),
         }
 
-        def save_checkpoint(self, path):
+        def __init__(self):
+            self.checkpoint_weight_modes = []
+
+        def save_checkpoint(self, path, weights_only=None):
+            self.checkpoint_weight_modes.append(weights_only)
             path.write_text("checkpoint")
 
     trainer = Trainer()
@@ -236,6 +240,7 @@ def test_packed_best_checkpoint_records_distinct_checkpoints(tmp_path):
         str(tmp_path / "packed_best_submodel_0.ckpt"),
         str(tmp_path / "packed_best_submodel_1.ckpt"),
     ]
+    assert trainer.checkpoint_weight_modes == [False, False]
 
 
 if __name__ == "__main__":

--- a/tests/test_nam/test_train/test_resources.py
+++ b/tests/test_nam/test_train/test_resources.py
@@ -1,0 +1,20 @@
+import json as _json
+from importlib import resources as _resources
+
+from nam.models.wavenet import PackedWaveNet as _PackedWaveNet
+
+
+def _load_packed_model_config():
+    resource = _resources.files("nam.train._resources").joinpath(
+        "config_model_packed.json"
+    )
+    with resource.open("r") as fp:
+        return _json.load(fp)
+
+
+def test_packaged_packed_model_config_loads():
+    config = _load_packed_model_config()
+
+    assert config["net"]["name"] == "PackedWaveNet"
+    model = _PackedWaveNet.init_from_config(config["net"]["config"])
+    assert model.num_submodels == len(config["net"]["config"]["submodels"])


### PR DESCRIPTION
## Summary

- Switch the simplified GUI and Colab trainers to NAM's A2, using the configuration for packed training.
- Remove simplified-trainer knobs for model type, architecture, learning rate decay, and MRSTFT fitting.
- Add packed-model support for best-checkpoint restoration, validation sizing, and per-submodel plot reporting.

## Details

The simplified training path now loads a packaged `PackedWaveNet` model config from `nam.train._resources`, and the package metadata includes that JSON resource. Core training chooses the matching Lightning module class from the model config, wires packed callbacks when needed, restores per-submodel best checkpoints after training, and plots each packed submodel's prediction with its ESR before reporting the aggregate ESR.

The GUI and Colab entry points now expose only the options that still affect simplified training. Documentation was updated to describe the fixed packed WaveNet behavior for simplified training and point full-trainer users toward the packed WaveNet config example.

Tests cover the removed public kwargs, packaged resource loading, packed plotting behavior, GUI independence from the old architecture enum, Colab forwarding behavior, packed checkpoint save mode, and WaveNet weight-import coverage without depending on removed core helpers.

## Testing

- `python -m pytest tests/test_nam/test_train/test_colab.py::test_colab_run_does_not_forward_removed_core_kwargs tests/test_nam/test_train/test_core.py::test_simplified_trainer_removed_knobs_are_absent_from_core_api tests/test_nam/test_train/test_core.py::test_get_configs_uses_packaged_packed_model_config tests/test_nam/test_train/test_core.py::test_plot_reports_and_plots_each_packed_prediction tests/test_nam/test_train/test_resources.py::test_packaged_packed_model_config_loads tests/test_nam/test_train/test_lightning_module.py::test_packed_best_checkpoint_records_distinct_checkpoints tests/test_nam/test_models/test_wavenet.py::TestWaveNet::test_import_weights tests/test_nam/test_train/test_gui/test_main.py::test_gui_does_not_depend_on_core_architecture`
  - 8 passed
