### PR TITLE
Target-RMS normalization with head_scale compensation

### DIFF
--- a/nam/train/_normalize.py
+++ b/nam/train/_normalize.py
@@ -1,0 +1,288 @@
+# File: _normalize.py
+# Author: TONE3000 - João Felipe Santos & Woodbury Shortridge
+
+"""
+Output-target RMS normalization with head_scale compensation.
+
+The training target ``y`` is scaled to a fixed RMS (with a peak-safety clamp)
+before training; the trained WaveNet's ``head_scale`` is then divided by the
+same gain so that the *exported* model produces the same output level as if
+no normalization had ever been applied. Normalization is therefore strictly a
+preconditioning step on the training data -- it does not change the model's
+inference-time response.
+
+This module is the single source of truth for the feature. ``nam.train.full``
+and ``nam.train.core`` invoke it via :func:`prepare` (before training) and
+:func:`compensate_head_scale` (after training).
+"""
+
+import warnings as _warnings
+from copy import deepcopy as _deepcopy
+from dataclasses import dataclass as _dataclass
+from typing import Dict as _Dict
+from typing import Optional as _Optional
+from typing import Tuple as _Tuple
+from typing import Union as _Union
+
+import numpy as _np
+import torch as _torch
+
+from ..data import wav_to_np as _wav_to_np
+
+# Default RMS target. -18 dBFS is a conventional broadcast/mixing reference and
+# leaves comfortable headroom for transients in guitar/amp captures.
+DEFAULT_TARGET_RMS_DBFS = -18.0
+
+# Strict cap on |y * gain|. The existing Dataset validation rejects |y| >= 1.0,
+# so we leave a small margin below unity.
+_PEAK_LIMIT = 1.0 - 1e-4
+
+# RMS below this is treated as silence; no normalization is applied.
+_SILENCE_RMS = 1e-8
+
+
+class OutputNormalizationSkippedWarning(UserWarning):
+    """
+    Emitted when output-target normalization was requested but had to be
+    skipped (e.g. the model architecture doesn't expose a ``head_scale``
+    we can post-hoc compensate).
+    """
+
+
+@_dataclass(frozen=True)
+class NormalizationPlan:
+    """
+    Result of :func:`prepare`.
+
+    :param data_config: A (possibly modified) data config with ``y_scale``
+        injected into ``common`` so both train and validation splits apply
+        the same gain.
+    :param gain: The gain that was applied to ``y``. After training, divide
+        the model's ``head_scale`` by this value via
+        :func:`compensate_head_scale`. ``1.0`` means a no-op.
+    :param target_rms_dbfs: The target dBFS that produced ``gain`` (``None``
+        when normalization is disabled / skipped).
+    """
+
+    data_config: _Dict
+    gain: float
+    target_rms_dbfs: _Optional[float]
+
+    @property
+    def applied(self) -> bool:
+        return self.gain != 1.0 and self.target_rms_dbfs is not None
+
+
+def _db_to_amp(db: float) -> float:
+    return 10.0 ** (db / 20.0)
+
+
+def compute_y_scale(
+    y: _Union[_np.ndarray, _torch.Tensor],
+    target_rms_dbfs: float = DEFAULT_TARGET_RMS_DBFS,
+) -> float:
+    """
+    Compute a scalar gain that:
+
+    1. Scales ``y`` to ``target_rms_dbfs`` RMS, then
+    2. Attenuates further if needed so that ``|gain * y|`` stays strictly
+       below 1.0 (peak-safety clamp).
+
+    Returns ``1.0`` if ``y`` is effectively silent.
+    """
+    arr = (
+        y.detach().to(_torch.float64).cpu().numpy()
+        if isinstance(y, _torch.Tensor)
+        else _np.asarray(y, dtype=_np.float64)
+    )
+    rms = float(_np.sqrt(_np.mean(arr * arr)))
+    if rms < _SILENCE_RMS:
+        return 1.0
+    gain = _db_to_amp(target_rms_dbfs) / rms
+    peak = float(_np.max(_np.abs(arr))) * gain
+    if peak > _PEAK_LIMIT:
+        gain *= _PEAK_LIMIT / peak
+    return float(gain)
+
+
+_DATA_CONFIG_KEY = "target_rms_dbfs"
+
+
+def parse_data_config(data_config: _Dict) -> _Optional[float]:
+    """
+    Read the top-level ``target_rms_dbfs`` field from a data config.
+
+    :return: Target dBFS to use, or ``None`` if normalization is disabled.
+
+    Conventions (mirrors how ``delay`` / ``nx`` live as flat top-level
+    fields elsewhere in this repo):
+
+    * Key missing -> enabled with :data:`DEFAULT_TARGET_RMS_DBFS`.
+    * ``null``    -> disabled.
+    * ``<float>`` -> enabled with that explicit target.
+    """
+    if _DATA_CONFIG_KEY not in data_config:
+        return DEFAULT_TARGET_RMS_DBFS
+    target = data_config[_DATA_CONFIG_KEY]
+    if target is None:
+        return None
+    if isinstance(target, bool) or not isinstance(target, (int, float)):
+        raise ValueError(
+            f"data_config[{_DATA_CONFIG_KEY!r}] must be null or a number; "
+            f"got {target!r}"
+        )
+    return float(target)
+
+
+def supports_head_scale_compensation(model_config: _Dict) -> bool:
+    """
+    True iff the model exposes a ``head_scale`` that we can post-hoc divide
+    by the applied gain without altering the model's response.
+
+    Currently:
+
+    * ``WaveNet``       -> supported when the top-level ``head`` is null.
+    * ``PackedWaveNet`` -> supported when the top-level and all submodels'
+                          ``head`` fields are null.
+
+    Models with a non-trivial top-level head are not supported because the
+    head's bias would not commute with a post-hoc output scaling.
+    """
+    net = model_config.get("net", {})
+    name = net.get("name")
+    cfg = net.get("config", {}) or {}
+    if name == "WaveNet":
+        return cfg.get("head") is None
+    if name == "PackedWaveNet":
+        if cfg.get("head") is not None:
+            return False
+        return all(
+            (sm.get("config", {}) or {}).get("head") is None
+            for sm in cfg.get("submodels", [])
+        )
+    return False
+
+
+def _resolve_train_y_path(data_config: _Dict) -> _Optional[str]:
+    """
+    Find the y_path used by the training split. We only normalize when this
+    can be resolved unambiguously (single y file feeding the training set).
+    """
+    common = data_config.get("common", {}) or {}
+    if "y_path" in common:
+        return common["y_path"]
+    train = data_config.get("train")
+    if isinstance(train, dict) and "y_path" in train:
+        return train["y_path"]
+    return None
+
+
+def prepare(
+    data_config: _Dict,
+    model_config: _Dict,
+    target_rms_dbfs: _Optional[float] = None,
+) -> NormalizationPlan:
+    """
+    Compute the normalization gain and return an updated data config that
+    applies it (via the dataset's existing ``y_scale``) uniformly to all
+    splits.
+
+    :param target_rms_dbfs: Overrides the value read from ``data_config``.
+        Pass ``None`` to use the value from ``data_config`` (or the default).
+        Pass an explicit value to override.
+
+    No-ops (returns ``gain == 1.0``) when:
+
+    * Normalization is disabled in the config (silent).
+    * The model does not support head_scale compensation (warns).
+    * The training ``y_path`` cannot be resolved (warns).
+    * The target signal is silent (silent).
+
+    Warnings use :class:`OutputNormalizationSkippedWarning`, a
+    :class:`UserWarning` subclass; tests can match it with
+    ``pytest.warns(OutputNormalizationSkippedWarning, match=...)``.
+    """
+    if target_rms_dbfs is None:
+        target_rms_dbfs = parse_data_config(data_config)
+    if target_rms_dbfs is None:
+        return NormalizationPlan(data_config, 1.0, None)
+    if not supports_head_scale_compensation(model_config):
+        net_name = (model_config.get("net", {}) or {}).get("name", "<unknown>")
+        _warnings.warn(
+            f"Output normalization (target {target_rms_dbfs:.1f} dBFS) was "
+            f"requested but model architecture {net_name!r} does not support "
+            "head_scale compensation; skipping. To silence this warning, set "
+            f"`{_DATA_CONFIG_KEY}` to null in the data config (or pass "
+            "`output_target_rms_dbfs=None`).",
+            OutputNormalizationSkippedWarning,
+            stacklevel=2,
+        )
+        return NormalizationPlan(data_config, 1.0, None)
+    y_path = _resolve_train_y_path(data_config)
+    if y_path is None:
+        _warnings.warn(
+            f"Output normalization (target {target_rms_dbfs:.1f} dBFS) was "
+            "requested but the training `y_path` could not be resolved from "
+            "the data config; skipping.",
+            OutputNormalizationSkippedWarning,
+            stacklevel=2,
+        )
+        return NormalizationPlan(data_config, 1.0, None)
+
+    y = _wav_to_np(y_path)
+    gain = compute_y_scale(y, target_rms_dbfs=target_rms_dbfs)
+    if gain == 1.0:
+        return NormalizationPlan(data_config, 1.0, target_rms_dbfs)
+
+    updated = _deepcopy(data_config)
+    common = updated.setdefault("common", {})
+    # Compose with any user-set y_scale so we never silently override it.
+    common["y_scale"] = float(common.get("y_scale", 1.0)) * gain
+    # Drop the directive from the propagated config so it isn't re-applied
+    # downstream by mistake.
+    updated.pop(_DATA_CONFIG_KEY, None)
+    return NormalizationPlan(updated, gain, target_rms_dbfs)
+
+
+def compensate_head_scale(net, gain: float) -> None:
+    """
+    Divide ``net``'s ``head_scale`` by ``gain`` in-place. ``net`` is the
+    public ``WaveNet`` / ``PackedWaveNet`` wrapper; both delegate to an
+    internal WaveNet that owns the ``_head_scale`` attribute.
+
+    For ``PackedWaveNet`` the per-submodel ``head_scale`` (held on the spec
+    and used when extracting submodels for export) is also updated, so the
+    exported container reflects the compensation.
+
+    No-op when ``gain == 1.0``.
+    """
+    if gain == 1.0:
+        return
+    if gain == 0.0 or not _np.isfinite(gain):
+        raise ValueError(f"Cannot compensate for non-finite/zero gain: {gain!r}")
+    internal = getattr(net, "_net", None)
+    if internal is None or not hasattr(internal, "_head_scale"):
+        raise TypeError(
+            f"{type(net).__name__} does not expose a head_scale to compensate"
+        )
+    new_value = float(internal._head_scale) / float(gain)
+    internal._head_scale = new_value
+    # PackedWaveNet mirrors head_scale in spec submodel configs; keep them in
+    # sync so extract_submodel() / _export_config see the new value.
+    spec = getattr(net, "_spec", None)
+    if spec is not None:
+        for sm in getattr(spec, "submodels", ()):
+            if "head_scale" in sm.config:
+                sm.config["head_scale"] = new_value
+
+
+__all__ = [
+    "DEFAULT_TARGET_RMS_DBFS",
+    "NormalizationPlan",
+    "OutputNormalizationSkippedWarning",
+    "compensate_head_scale",
+    "compute_y_scale",
+    "parse_data_config",
+    "prepare",
+    "supports_head_scale_compensation",
+]

--- a/nam/train/colab.py
+++ b/nam/train/colab.py
@@ -11,6 +11,7 @@ from typing import Optional as _Optional
 from typing import Tuple as _Tuple
 
 from ..models.metadata import UserMetadata as _UserMetadata
+from . import _normalize as _normalize_mod
 from ._names import INPUT_BASENAMES as _INPUT_BASENAMES
 from ._names import LATEST_VERSION as _LATEST_VERSION
 from ._names import Version as _Version
@@ -94,6 +95,9 @@ def run(
     seed: _Optional[int] = 0,
     user_metadata: _Optional[_UserMetadata] = None,
     ignore_checks: bool = False,
+    output_target_rms_dbfs: _Optional[
+        float
+    ] = _normalize_mod.DEFAULT_TARGET_RMS_DBFS,
 ):
     """
     :param epochs: How many epochs we'll train for.
@@ -102,6 +106,10 @@ def run(
     :param seed: RNG seed for reproducibility.
     :param user_metadata: User-specified metadata to include in the .nam file.
     :param ignore_checks: Ignores the data quality checks and YOLOs it
+    :param output_target_rms_dbfs: RMS target (dBFS) the training output is
+        scaled to before training; the exported model's ``head_scale`` is
+        compensated so inference levels are unchanged. Pass ``None`` to
+        disable.
     """
 
     input_basename = _check_for_files()
@@ -115,6 +123,7 @@ def run(
         seed=seed,
         local=False,
         ignore_checks=ignore_checks,
+        output_target_rms_dbfs=output_target_rms_dbfs,
     )
     model = train_output.model
     training_metadata = train_output.metadata

--- a/nam/train/core.py
+++ b/nam/train/core.py
@@ -43,6 +43,7 @@ from ..models.exportable import Exportable as _Exportable
 from ..models.losses import esr as _ESR
 from ..models.metadata import UserMetadata as _UserMetadata
 from ..util import filter_warnings as _filter_warnings
+from . import _normalize as _normalize_mod
 from . import metadata as _metadata
 from ._version import PROTEUS_VERSION as _PROTEUS_VERSION
 from ._version import Version as _Version
@@ -1303,12 +1304,17 @@ def train(
     threshold_esr: _Optional[float] = None,
     user_metadata: _Optional[_UserMetadata] = None,
     fast_dev_run: _Union[bool, int] = False,
+    output_target_rms_dbfs: _Optional[float] = _normalize_mod.DEFAULT_TARGET_RMS_DBFS,
 ) -> _Optional[TrainOutput]:
     """
     :param input_path: Full path to input file
     :param output_path: Full path to output file
     :param threshold_esr: Stop training if ESR is better than this. Ignore if `None`.
     :param fast_dev_run: One-step training, used for tests.
+    :param output_target_rms_dbfs: RMS target (dBFS) for the training output
+        signal. The training target is scaled to this RMS (with peak-safety
+        clamp) and the exported model's ``head_scale`` is divided by the same
+        gain so that inference levels are unchanged. Pass ``None`` to disable.
     """
 
     if seed is not None:
@@ -1384,6 +1390,20 @@ def train(
     assert (
         "fast_dev_run" not in learning_config
     ), "fast_dev_run is set as a kwarg to train()"
+
+    # Output-target RMS normalization: scale the training target so it sits at
+    # a fixed RMS, then later divide the model's head_scale by the same gain
+    # so inference levels match the original capture.
+    normalization = _normalize_mod.prepare(
+        data_config, model_config, target_rms_dbfs=output_target_rms_dbfs
+    )
+    data_config = normalization.data_config
+    if normalization.applied:
+        print(
+            f"Normalizing training target to {normalization.target_rms_dbfs:.1f} "
+            f"dBFS RMS (gain={normalization.gain:.6g}); head_scale will be "
+            f"compensated after training."
+        )
 
     print("Starting training. It's time to kick ass and chew bubblegum!")
     # Issue:
@@ -1476,6 +1496,10 @@ def train(
             silent=silent,
             **window_kwargs(input_version),
         )
+        # Undo training-time target normalization on the exported model so that
+        # inference levels match the original capture. Done after plotting
+        # because the plot's reference y is in the scaled domain.
+        _normalize_mod.compensate_head_scale(model.net, normalization.gain)
         for dl in (train_dataloader, val_dataloader):
             assert isinstance(dl.dataset, _AbstractDataset)
             dl.dataset.teardown()

--- a/nam/train/full.py
+++ b/nam/train/full.py
@@ -21,6 +21,7 @@ from torch.utils.data import DataLoader as _DataLoader
 from nam.data import ConcatDataset as _ConcatDataset
 from nam.data import Split as _Split
 from nam.data import init_dataset as _init_dataset
+from nam.train import _normalize as _normalize_mod
 from nam.train import lightning_module as _lightning_module
 from nam.util import filter_warnings as _filter_warnings
 
@@ -205,6 +206,18 @@ def main(
         else _lightning_module.LightningModule
     )
     model = lightning_cls.init_from_config(model_config)
+
+    # Output-target normalization: scale y to a fixed RMS before training and
+    # remember the gain so we can compensate `head_scale` after training.
+    normalization = _normalize_mod.prepare(data_config, model_config)
+    data_config = normalization.data_config
+    if normalization.applied:
+        print(
+            f"Normalizing training target to {normalization.target_rms_dbfs:.1f} "
+            f"dBFS RMS (gain={normalization.gain:.6g}); head_scale will be "
+            f"compensated after training."
+        )
+
     # Add receptive field to data config:
     data_config["common"] = data_config.get("common", {})
     if "nx" in data_config["common"]:
@@ -266,6 +279,8 @@ def main(
         model.cpu()
         model.eval()
         if make_plots:
+            # Plot against the (scaled) validation y while the model is still
+            # in the training-time scale domain.
             _plot(
                 model,
                 dataset_validation,
@@ -275,6 +290,9 @@ def main(
                 show=False,
             )
             _plot(model, dataset_validation, show=not no_show)
+        # Undo the training-time target normalization on the exported model so
+        # inference matches the original capture level.
+        _normalize_mod.compensate_head_scale(model.net, normalization.gain)
         # Export!
         if is_packed:
             checkpoint_paths = (

--- a/nam/train/gui/__init__.py
+++ b/nam/train/gui/__init__.py
@@ -53,6 +53,7 @@ try:  # 3rd-party and 1st-party imports
     from nam.models.metadata import UserMetadata as _UserMetadata
 
     # Ok private access here--this is technically allowed access
+    from nam.train import _normalize as _normalize_mod
     from nam.train import core as _core
     from nam.train import metadata as _metadata
     from nam.train._names import INPUT_BASENAMES as _INPUT_BASENAMES
@@ -80,6 +81,9 @@ _TEXT_WIDTH = 70
 _DEFAULT_DELAY = None
 _DEFAULT_IGNORE_CHECKS = False
 _DEFAULT_THRESHOLD_ESR = None
+_DEFAULT_OUTPUT_TARGET_RMS_DBFS = (
+    _normalize_mod.DEFAULT_TARGET_RMS_DBFS if _install_is_valid else -18.0
+)
 
 _ADVANCED_OPTIONS_LEFT_WIDTH = 12
 _ADVANCED_OPTIONS_RIGHT_WIDTH = 12
@@ -132,12 +136,16 @@ class AdvancedOptions(object):
     :param ignore_checks: Keep going even if a check says that something is wrong.
     :param threshold_esr: Stop training if the ESR gets better than this. If None, don't
         stop.
+    :param output_target_rms_dbfs: RMS target (dBFS) the training output is
+        scaled to before training; the exported model's ``head_scale`` is
+        compensated so inference levels are unchanged. ``None`` disables.
     """
 
     num_epochs: int
     latency: _Optional[int]
     ignore_checks: bool
     threshold_esr: _Optional[float]
+    output_target_rms_dbfs: _Optional[float]
 
 
 class _PathType(_Enum):
@@ -539,6 +547,7 @@ class GUI(object):
             latency=_DEFAULT_DELAY,
             ignore_checks=_DEFAULT_IGNORE_CHECKS,
             threshold_esr=_DEFAULT_THRESHOLD_ESR,
+            output_target_rms_dbfs=_DEFAULT_OUTPUT_TARGET_RMS_DBFS,
         )
         # Window to edit them:
 
@@ -713,6 +722,7 @@ class GUI(object):
         user_latency = self.advanced_options.latency
         file_list = self._widgets[_GUIWidgets.OUTPUT_PATH].val
         threshold_esr = self.advanced_options.threshold_esr
+        output_target_rms_dbfs = self.advanced_options.output_target_rms_dbfs
 
         # Run it
         for file in file_list:
@@ -735,6 +745,7 @@ class GUI(object):
                 local=True,
                 threshold_esr=threshold_esr,
                 user_metadata=user_metadata,
+                output_target_rms_dbfs=output_target_rms_dbfs,
                 **self.core_train_kwargs(),
             )
 
@@ -1123,7 +1134,12 @@ class AdvancedOptionsGUI(object):
             except ValueError:
                 pass
 
-        for name in ("num_epochs", "latency", "threshold_esr"):
+        for name in (
+            "num_epochs",
+            "latency",
+            "threshold_esr",
+            "output_target_rms_dbfs",
+        ):
             safe_apply(name)
 
     def pack(self):
@@ -1160,6 +1176,29 @@ class AdvancedOptionsGUI(object):
             "Threshold ESR",
             default=_float_or_null.inverse(self._parent.advanced_options.threshold_esr),
             type=_float_or_null.forward,
+        )
+
+        # Output target RMS (dBFS) -- normalizes the training target so the
+        # loss sees a fixed loudness; head_scale is compensated after training
+        # so inference levels are unchanged. Blank disables normalization.
+        self._frame_output_target_rms_dbfs = _tk.Frame(self._root)
+        self._frame_output_target_rms_dbfs.pack()
+        self._output_target_rms_dbfs = LabeledText(
+            self._frame_output_target_rms_dbfs,
+            "Output target RMS (dBFS)",
+            default=_float_or_null.inverse(
+                self._parent.advanced_options.output_target_rms_dbfs
+            ),
+            type=_float_or_null.forward,
+        )
+        self._output_target_rms_dbfs.label_tooltip = _Hovertip(
+            anchor_widget=self._output_target_rms_dbfs.label,
+            text=(
+                "Target RMS (dBFS) the training output is scaled to before\n"
+                "training. The exported model's head_scale is divided by the\n"
+                "same gain so inference levels are unchanged.\n"
+                "Leave blank to disable normalization."
+            ),
         )
 
 

--- a/nam_full_configs/data/single_pair.json
+++ b/nam_full_configs/data/single_pair.json
@@ -17,5 +17,6 @@
         "x_path": "C:\\path\\to\\source.wav",
         "y_path": "C:\\path\\to\\target.wav",
         "delay": 0
-    }
+    },
+    "target_rms_dbfs": -18.0
 }

--- a/nam_full_configs/data/two_pairs.json
+++ b/nam_full_configs/data/two_pairs.json
@@ -15,5 +15,6 @@
     },
     "common": {
         "delay": 0
-    }
+    },
+    "target_rms_dbfs": -18.0
 }

--- a/tests/test_nam/test_train/test_gui/test_main.py
+++ b/tests/test_nam/test_train/test_gui/test_main.py
@@ -32,5 +32,19 @@ def test_gui_does_not_depend_on_core_architecture():
     assert "_core.Architecture" not in source
 
 
+def test_advanced_options_exposes_output_target_rms_dbfs():
+    """AdvancedOptions carries the normalization knob with the shared default."""
+    from nam.train import _normalize as _norm
+
+    opts = gui.AdvancedOptions(
+        num_epochs=1,
+        latency=None,
+        ignore_checks=False,
+        threshold_esr=None,
+        output_target_rms_dbfs=_norm.DEFAULT_TARGET_RMS_DBFS,
+    )
+    assert opts.output_target_rms_dbfs == _norm.DEFAULT_TARGET_RMS_DBFS
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_nam/test_train/test_normalize.py
+++ b/tests/test_nam/test_train/test_normalize.py
@@ -1,0 +1,576 @@
+# File: test_normalize.py
+# Tests for nam.train._normalize.
+
+import json
+import warnings as _warnings
+from copy import deepcopy
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from nam.data import np_to_wav, wav_to_np
+from nam.models.wavenet import PackedWaveNet, WaveNet
+from nam.train import _normalize as _norm
+from nam.train import full as _full
+
+
+_RATE = 48_000
+
+
+def _db_to_amp(db: float) -> float:
+    return 10.0 ** (db / 20.0)
+
+
+def _rms(x: np.ndarray) -> float:
+    return float(np.sqrt(np.mean(x.astype(np.float64) ** 2)))
+
+
+# ---------------------------------------------------------------------------
+# compute_y_scale
+# ---------------------------------------------------------------------------
+
+
+class TestComputeYScale:
+    def test_rms_branch_hits_target(self):
+        """A quiet signal is scaled up to exactly the target RMS."""
+        target_dbfs = -18.0
+        target_rms = _db_to_amp(target_dbfs)
+        # Quiet sine: RMS = 0.1 / sqrt(2) ~ 0.0707; peak << 1 even after scaling.
+        t = np.arange(_RATE, dtype=np.float64) / _RATE
+        y = 0.1 * np.sin(2.0 * np.pi * 220.0 * t)
+
+        gain = _norm.compute_y_scale(y, target_rms_dbfs=target_dbfs)
+
+        scaled_rms = _rms(y * gain)
+        np.testing.assert_allclose(scaled_rms, target_rms, rtol=1e-6)
+        assert np.max(np.abs(y * gain)) < 1.0
+
+    def test_peak_clamp_activates_for_hot_signal(self):
+        """A signal whose RMS-normalized peak would exceed 1.0 gets clamped."""
+        # Pulse: RMS << peak. RMS-normalizing to -18 dBFS pushes peak above 1.
+        y = np.zeros(_RATE, dtype=np.float64)
+        y[::100] = 0.9  # Sparse, very peaky.
+
+        gain = _norm.compute_y_scale(y, target_rms_dbfs=-6.0)
+
+        scaled = y * gain
+        peak = float(np.max(np.abs(scaled)))
+        assert peak < 1.0
+        # Peak is clamped strictly below 1.0 to satisfy Dataset validation.
+        assert peak >= 0.999 * (1.0 - 1e-4)
+
+    def test_silent_input_returns_one(self):
+        y = np.zeros(_RATE, dtype=np.float64)
+        assert _norm.compute_y_scale(y) == 1.0
+
+    def test_accepts_torch_tensor(self):
+        y = 0.1 * torch.randn(_RATE)
+        gain = _norm.compute_y_scale(y, target_rms_dbfs=-18.0)
+        assert gain > 1.0  # Quiet random -> scaled up.
+
+
+# ---------------------------------------------------------------------------
+# parse_data_config
+# ---------------------------------------------------------------------------
+
+
+class TestParseDataConfig:
+    def test_missing_key_defaults_on(self):
+        assert _norm.parse_data_config({}) == _norm.DEFAULT_TARGET_RMS_DBFS
+
+    def test_null_disables(self):
+        assert _norm.parse_data_config({"target_rms_dbfs": None}) is None
+
+    def test_explicit_target(self):
+        assert _norm.parse_data_config({"target_rms_dbfs": -12.0}) == -12.0
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError):
+            _norm.parse_data_config({"target_rms_dbfs": "loud"})
+        with pytest.raises(ValueError):
+            _norm.parse_data_config({"target_rms_dbfs": True})
+
+
+# ---------------------------------------------------------------------------
+# supports_head_scale_compensation
+# ---------------------------------------------------------------------------
+
+
+def _wavenet_model_config(head=None):
+    return {
+        "net": {
+            "name": "WaveNet",
+            "config": {
+                "layers_configs": [
+                    {
+                        "input_size": 1,
+                        "condition_size": 1,
+                        "channels": 2,
+                        "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
+                        "kernel_size": 2,
+                        "dilations": [1],
+                        "activation": "Tanh",
+                    }
+                ],
+                "head": head,
+                "head_scale": 0.25,
+            },
+        }
+    }
+
+
+def _packed_model_config():
+    submodel = {
+        "name": "only",
+        "config": {
+            "layers_configs": [
+                {
+                    "input_size": 1,
+                    "condition_size": 1,
+                    "channels": 2,
+                    "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
+                    "kernel_size": 2,
+                    "dilations": [1],
+                    "activation": "Tanh",
+                }
+            ],
+            "head": None,
+            "head_scale": 0.25,
+        },
+    }
+    return {
+        "net": {
+            "name": "PackedWaveNet",
+            "config": {"submodels": [submodel]},
+        }
+    }
+
+
+def _slimmable_model_config():
+    """Slimmable WaveNet is just a WaveNet with a per-layer 'slimmable' block."""
+    return {
+        "net": {
+            "name": "WaveNet",
+            "config": {
+                "layers_configs": [
+                    {
+                        "input_size": 1,
+                        "condition_size": 1,
+                        "channels": 4,
+                        "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
+                        "kernel_size": 2,
+                        "dilations": [1, 2],
+                        "activation": "Tanh",
+                        "slimmable": {
+                            "method": "slice_channels_uniform",
+                            "kwargs": {"allowed_channels": [2, 4]},
+                        },
+                    }
+                ],
+                "head_scale": 0.25,
+            },
+        }
+    }
+
+
+class TestSupportsHeadScaleCompensation:
+    def test_wavenet_no_head(self):
+        assert _norm.supports_head_scale_compensation(_wavenet_model_config())
+
+    def test_wavenet_with_top_head_unsupported(self):
+        cfg = _wavenet_model_config(
+            head={"channels": 1, "activation": "Tanh", "out_channels": 1, "kernel_sizes": [1]}
+        )
+        assert not _norm.supports_head_scale_compensation(cfg)
+
+    def test_packed_wavenet_no_head(self):
+        assert _norm.supports_head_scale_compensation(_packed_model_config())
+
+    def test_slimmable_wavenet_no_head(self):
+        assert _norm.supports_head_scale_compensation(_slimmable_model_config())
+
+    def test_unsupported_architecture(self):
+        assert not _norm.supports_head_scale_compensation(
+            {"net": {"name": "ConvNet", "config": {}}}
+        )
+
+
+# ---------------------------------------------------------------------------
+# compensate_head_scale
+# ---------------------------------------------------------------------------
+
+
+class TestCompensateHeadScale:
+    def test_wavenet(self):
+        net = WaveNet.init_from_config(_wavenet_model_config()["net"]["config"])
+        original = net._net._head_scale
+        _norm.compensate_head_scale(net, 2.0)
+        assert net._net._head_scale == pytest.approx(original / 2.0)
+
+    def test_packed_wavenet(self):
+        net = PackedWaveNet.init_from_config(_packed_model_config()["net"]["config"])
+        original = net._net._head_scale
+        _norm.compensate_head_scale(net, 4.0)
+        assert net._net._head_scale == pytest.approx(original / 4.0)
+
+    def test_gain_of_one_is_noop(self):
+        net = WaveNet.init_from_config(_wavenet_model_config()["net"]["config"])
+        original = net._net._head_scale
+        _norm.compensate_head_scale(net, 1.0)
+        assert net._net._head_scale == original
+
+    def test_invalid_gain_raises(self):
+        net = WaveNet.init_from_config(_wavenet_model_config()["net"]["config"])
+        with pytest.raises(ValueError):
+            _norm.compensate_head_scale(net, 0.0)
+        with pytest.raises(ValueError):
+            _norm.compensate_head_scale(net, float("inf"))
+
+
+# ---------------------------------------------------------------------------
+# prepare
+# ---------------------------------------------------------------------------
+
+
+def _write_quiet_target(tmp_path: Path, num_seconds: float = 0.5) -> Path:
+    n = int(num_seconds * _RATE)
+    t = np.arange(n, dtype=np.float64) / _RATE
+    # 0.1-amp sine -> RMS ~ 0.0707, needs ~1.8x to reach -18 dBFS RMS.
+    y = 0.1 * np.sin(2.0 * np.pi * 220.0 * t)
+    path = tmp_path / "target.wav"
+    np_to_wav(y, path, rate=_RATE)
+    return path
+
+
+class TestPrepare:
+    def test_default_on_for_wavenet(self, tmp_path):
+        y_path = _write_quiet_target(tmp_path)
+        data_config = {"common": {"y_path": str(y_path)}, "train": {}, "validation": {}}
+        plan = _norm.prepare(data_config, _wavenet_model_config())
+        assert plan.applied
+        assert plan.gain > 1.0
+        assert plan.data_config["common"]["y_scale"] == pytest.approx(plan.gain)
+        # Directive consumed so it's not double-applied downstream.
+        assert "target_rms_dbfs" not in plan.data_config
+
+    def test_explicit_disable(self, tmp_path):
+        y_path = _write_quiet_target(tmp_path)
+        data_config = {
+            "common": {"y_path": str(y_path)},
+            "train": {},
+            "validation": {},
+            "target_rms_dbfs": None,
+        }
+        plan = _norm.prepare(data_config, _wavenet_model_config())
+        assert not plan.applied
+        assert plan.gain == 1.0
+        assert "y_scale" not in plan.data_config.get("common", {})
+
+    def test_unsupported_model_warns_and_noop(self, tmp_path):
+        y_path = _write_quiet_target(tmp_path)
+        data_config = {"common": {"y_path": str(y_path)}, "train": {}, "validation": {}}
+        with pytest.warns(
+            _norm.OutputNormalizationSkippedWarning, match=r"ConvNet"
+        ):
+            plan = _norm.prepare(
+                data_config, {"net": {"name": "ConvNet", "config": {}}}
+            )
+        assert not plan.applied
+        assert plan.gain == 1.0
+
+    def test_unsupported_model_silent_when_disabled(self):
+        """If the user disabled normalization, no warning for unsupported models."""
+        data_config = {"common": {}, "train": {}, "target_rms_dbfs": None}
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error", _norm.OutputNormalizationSkippedWarning)
+            plan = _norm.prepare(
+                data_config, {"net": {"name": "ConvNet", "config": {}}}
+            )
+        assert not plan.applied
+
+    def test_unresolvable_y_path_warns(self):
+        data_config = {
+            "common": {},
+            "train": [],  # list-typed -> can't resolve a single train y_path
+            "validation": [],
+        }
+        with pytest.warns(
+            _norm.OutputNormalizationSkippedWarning, match=r"y_path"
+        ):
+            plan = _norm.prepare(data_config, _wavenet_model_config())
+        assert not plan.applied
+
+    def test_two_pairs_uses_train_y_path(self, tmp_path):
+        y_path = _write_quiet_target(tmp_path)
+        data_config = {
+            "common": {},
+            "train": {"y_path": str(y_path)},
+            "validation": {"y_path": str(y_path)},
+        }
+        plan = _norm.prepare(data_config, _wavenet_model_config())
+        assert plan.applied
+        assert plan.data_config["common"]["y_scale"] == pytest.approx(plan.gain)
+
+    def test_composes_with_existing_y_scale(self, tmp_path):
+        y_path = _write_quiet_target(tmp_path)
+        data_config = {
+            "common": {"y_path": str(y_path), "y_scale": 2.0},
+            "train": {},
+            "validation": {},
+        }
+        plan = _norm.prepare(data_config, _wavenet_model_config())
+        assert plan.data_config["common"]["y_scale"] == pytest.approx(2.0 * plan.gain)
+
+    def test_explicit_override_target(self, tmp_path):
+        y_path = _write_quiet_target(tmp_path)
+        data_config = {"common": {"y_path": str(y_path)}, "train": {}, "validation": {}}
+        plan = _norm.prepare(
+            data_config, _wavenet_model_config(), target_rms_dbfs=-30.0
+        )
+        assert plan.target_rms_dbfs == -30.0
+        # Quieter target -> smaller gain than default -18 dBFS.
+        default_plan = _norm.prepare(data_config, _wavenet_model_config())
+        assert plan.gain < default_plan.gain
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full.main exports model with compensated head_scale
+# ---------------------------------------------------------------------------
+
+
+_E2E_NUM_SAMPLES = 256
+_E2E_NUM_VAL = 64
+_E2E_NY = 8
+
+
+def _e2e_write_wav_pair(tmp_path):
+    t = np.arange(_E2E_NUM_SAMPLES, dtype=np.float64) / _RATE
+    x = 0.10 * np.sin(2.0 * np.pi * 220.0 * t)
+    y = 0.05 * x + 0.005 * np.sin(2.0 * np.pi * 440.0 * t)
+    x_path = tmp_path / "input.wav"
+    y_path = tmp_path / "output.wav"
+    np_to_wav(x, x_path, rate=_RATE)
+    np_to_wav(y, y_path, rate=_RATE)
+    return x_path, y_path
+
+
+def _e2e_data_config(x_path, y_path, target_rms_dbfs):
+    config = {
+        "common": {
+            "x_path": str(x_path),
+            "y_path": str(y_path),
+            "delay": 0,
+            "require_input_pre_silence": None,
+        },
+        "train": {"stop_samples": -_E2E_NUM_VAL, "ny": _E2E_NY},
+        "validation": {"start_samples": -_E2E_NUM_VAL, "ny": None},
+    }
+    if target_rms_dbfs is not _UNSET:
+        config["target_rms_dbfs"] = target_rms_dbfs
+    return config
+
+
+_UNSET = object()
+
+
+_E2E_HEAD_SCALE = 0.25
+
+
+def _e2e_wavenet_model_config():
+    return {
+        "net": {
+            "name": "WaveNet",
+            "config": {
+                "layers_configs": [
+                    {
+                        "input_size": 1,
+                        "condition_size": 1,
+                        "channels": 2,
+                        "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
+                        "kernel_size": 2,
+                        "dilations": [1],
+                        "activation": "Tanh",
+                    }
+                ],
+                "head": None,
+                "head_scale": _E2E_HEAD_SCALE,
+            },
+        },
+        "optimizer": {"lr": 0.001},
+        "lr_scheduler": None,
+        "loss": {"val_loss": "mse"},
+    }
+
+
+def _e2e_packed_model_config():
+    sub = _e2e_wavenet_model_config()["net"]["config"]
+    return {
+        "net": {
+            "name": "PackedWaveNet",
+            "config": {
+                "submodels": [
+                    {"name": "small", "config": deepcopy(sub)},
+                    {"name": "large", "config": deepcopy(sub)},
+                ],
+            },
+        },
+        "optimizer": {"lr": 0.001},
+        "lr_scheduler": None,
+        "loss": {"val_loss": "mse"},
+    }
+
+
+def _e2e_slimmable_model_config():
+    return {
+        "net": {
+            "name": "WaveNet",
+            "config": {
+                "layers_configs": [
+                    {
+                        "input_size": 1,
+                        "condition_size": 1,
+                        "channels": 4,
+                        "head": {"out_channels": 1, "kernel_size": 1, "bias": True},
+                        "kernel_size": 2,
+                        "dilations": [1],
+                        "activation": "Tanh",
+                        "slimmable": {
+                            "method": "slice_channels_uniform",
+                            "kwargs": {"allowed_channels": [2, 4]},
+                        },
+                    }
+                ],
+                "head": None,
+                "head_scale": _E2E_HEAD_SCALE,
+            },
+        },
+        "optimizer": {"lr": 0.001},
+        "lr_scheduler": None,
+        "loss": {"val_loss": "mse"},
+    }
+
+
+def _e2e_learning_config():
+    return {
+        "train_dataloader": {
+            "batch_size": 2,
+            "shuffle": False,
+            "drop_last": False,
+            "num_workers": 0,
+        },
+        "val_dataloader": {"batch_size": 1, "num_workers": 0},
+        "trainer": {
+            "accelerator": "cpu",
+            "devices": 1,
+            "max_epochs": 1,
+            "limit_train_batches": 1,
+            "limit_val_batches": 1,
+            "num_sanity_val_steps": 0,
+            "enable_progress_bar": False,
+            "enable_model_summary": False,
+            "logger": False,
+        },
+        "trainer_fit_kwargs": {},
+    }
+
+
+def _expected_gain_from_file(y_path: Path) -> float:
+    y = wav_to_np(str(y_path))
+    return _norm.compute_y_scale(y, target_rms_dbfs=_norm.DEFAULT_TARGET_RMS_DBFS)
+
+
+class TestFullMainCompensation:
+    def test_wavenet_head_scale_is_compensated(self, tmp_path):
+        x_path, y_path = _e2e_write_wav_pair(tmp_path)
+        outdir = tmp_path / "out"
+        outdir.mkdir()
+
+        expected_gain = _expected_gain_from_file(y_path)
+        assert expected_gain > 1.0  # Sanity: data is quiet enough to scale up.
+
+        _full.main(
+            _e2e_data_config(x_path, y_path, _UNSET),
+            _e2e_wavenet_model_config(),
+            _e2e_learning_config(),
+            outdir,
+            no_show=True,
+            make_plots=False,
+        )
+
+        with open(outdir / "model.nam", "r") as fp:
+            exported = json.load(fp)
+        actual = float(exported["config"]["head_scale"])
+        assert actual == pytest.approx(_E2E_HEAD_SCALE / expected_gain, rel=1e-5)
+
+    def test_disable_via_null_keeps_head_scale(self, tmp_path):
+        x_path, y_path = _e2e_write_wav_pair(tmp_path)
+        outdir = tmp_path / "out_disabled"
+        outdir.mkdir()
+
+        _full.main(
+            _e2e_data_config(x_path, y_path, None),
+            _e2e_wavenet_model_config(),
+            _e2e_learning_config(),
+            outdir,
+            no_show=True,
+            make_plots=False,
+        )
+
+        with open(outdir / "model.nam", "r") as fp:
+            exported = json.load(fp)
+        # No normalization applied -> head_scale persists as configured.
+        assert float(exported["config"]["head_scale"]) == pytest.approx(
+            _E2E_HEAD_SCALE, rel=1e-5
+        )
+
+    def test_slimmable_wavenet_head_scale_is_compensated(self, tmp_path):
+        x_path, y_path = _e2e_write_wav_pair(tmp_path)
+        outdir = tmp_path / "out_slimmable"
+        outdir.mkdir()
+
+        expected_gain = _expected_gain_from_file(y_path)
+        assert expected_gain > 1.0
+
+        _full.main(
+            _e2e_data_config(x_path, y_path, _UNSET),
+            _e2e_slimmable_model_config(),
+            _e2e_learning_config(),
+            outdir,
+            no_show=True,
+            make_plots=False,
+        )
+
+        with open(outdir / "model.nam", "r") as fp:
+            exported = json.load(fp)
+        actual = float(exported["config"]["head_scale"])
+        assert actual == pytest.approx(_E2E_HEAD_SCALE / expected_gain, rel=1e-5)
+
+    def test_packed_wavenet_head_scale_is_compensated(self, tmp_path):
+        x_path, y_path = _e2e_write_wav_pair(tmp_path)
+        outdir = tmp_path / "out_packed"
+        outdir.mkdir()
+
+        expected_gain = _expected_gain_from_file(y_path)
+        assert expected_gain > 1.0
+
+        _full.main(
+            _e2e_data_config(x_path, y_path, _UNSET),
+            _e2e_packed_model_config(),
+            _e2e_learning_config(),
+            outdir,
+            no_show=True,
+            make_plots=False,
+        )
+
+        with open(outdir / "model.nam", "r") as fp:
+            container = json.load(fp)
+
+        # Every packed submodel shares the same head_scale -> all compensated.
+        submodels = container["config"]["submodels"]
+        assert len(submodels) == 2
+        for entry in submodels:
+            assert float(entry["model"]["config"]["head_scale"]) == pytest.approx(
+                _E2E_HEAD_SCALE / expected_gain, rel=1e-5
+            )


### PR DESCRIPTION
## Summary
- Scales the training target to a fixed RMS (default **-18 dBFS**) with a peak-safety clamp before training; compensates the model's `head_scale` after training so inference levels match the original capture.
- Default **on** in `nam-full`, simplified trainer (`core.train`), Colab (`run`), and GUI. Pass `null` / `None` to disable, or set `target_rms_dbfs: null` in the data config.
- Supports `WaveNet`, slimmable `WaveNet`, and `PackedWaveNet` (no top-level head). Unsupported models skip with an `OutputNormalizationSkippedWarning`.

## Files
- `nam/train/_normalize.py` — single source of truth for the feature.
- `nam/train/full.py`, `core.py`, `colab.py`, `gui/__init__.py` — wiring.
- `nam_full_configs/data/{single_pair,two_pairs}.json` — declares the new top-level `target_rs` field.
- `tests/test_nam/test_train/test_normalize.py` — 29 unit + e2e tests.

## Test plan
- [x] `pytest tests/test_nam/test_train/test_normalize.py -v` → 29 passed
- [x] `pytest tests/test_nam/test_train/ tests/test_nam_full_configs.py` → green
- [ ] Manual: open GUI Advanced Options and confirm new "Output target RMS (dBFS)" field
- [x] Manual: train a model end-to-end and verify the trainer logs `Normalizing training target to -18.0 dBFS RMS (gain=...)`