### PR TITLE
[FEATURE] Support hooks post model dict formation in `.export()`

### DIFF
--- a/nam/models/exportable.py
+++ b/nam/models/exportable.py
@@ -9,7 +9,9 @@ from datetime import datetime as _datetime
 from enum import Enum as _Enum
 from pathlib import Path as _Path
 from typing import Any as _Any
+from typing import Callable as _Callable
 from typing import Dict as _Dict
+from typing import List as _List
 from typing import Optional as _Optional
 from typing import Sequence as _Sequence
 from typing import Tuple as _Tuple
@@ -41,6 +43,8 @@ def _cast_enums(d: _Dict[_Any, _Any]) -> _Dict[_Any, _Any]:
 _JsonDumpable = (
     dict[str, "_JsonDumpable"] | list["_JsonDumpable"] | str | int | float | bool | None
 )
+_ExportModelDict = _Dict[str, _JsonDumpable]
+_ExportModelDictPostHook = _Callable[[_ExportModelDict], _ExportModelDict]
 
 
 class Exportable(_abc.ABC):
@@ -49,6 +53,27 @@ class Exportable(_abc.ABC):
     """
 
     FILE_EXTENSION = ".nam"
+
+    def __init__(self):
+        self.export_model_dict_post_hooks = []
+
+    @property
+    def export_model_dict_post_hooks(self) -> _List[_ExportModelDictPostHook]:
+        """
+        Hooks run after the model export dictionary has been assembled.
+
+        Hooks return the model dictionary that should be passed to the next hook
+        and written to disk.
+        """
+        if "_export_model_dict_post_hooks" not in self.__dict__:
+            self._export_model_dict_post_hooks = []
+        return self._export_model_dict_post_hooks
+
+    @export_model_dict_post_hooks.setter
+    def export_model_dict_post_hooks(
+        self, hooks: _Sequence[_ExportModelDictPostHook]
+    ) -> None:
+        self._export_model_dict_post_hooks = list(hooks)
 
     def export(
         self,
@@ -86,6 +111,7 @@ class Exportable(_abc.ABC):
                     + "\n ".join(overwritten_keys)
                 )
             model_dict["metadata"].update(_cast_enums(other_metadata))
+        model_dict = self._apply_export_model_dict_post_hooks(model_dict=model_dict)
 
         training = self.training
         self.eval()
@@ -148,10 +174,17 @@ class Exportable(_abc.ABC):
         """
         pass
 
+    def _apply_export_model_dict_post_hooks(
+        self, model_dict: _ExportModelDict
+    ) -> _ExportModelDict:
+        for hook in self.export_model_dict_post_hooks:
+            model_dict = hook(model_dict)
+        return model_dict
+
     def _get_export_architecture(self) -> str:
         return self.__class__.__name__
 
-    def _get_export_dict(self) -> _Dict[str, _JsonDumpable]:
+    def _get_export_dict(self) -> _ExportModelDict:
         return {
             "version": _MODEL_VERSION,
             "metadata": self._get_non_user_metadata(),

--- a/tests/test_nam/test_models/test_exportable.py
+++ b/tests/test_nam/test_models/test_exportable.py
@@ -168,6 +168,79 @@ class TestExportable(object):
                 assert training_key in model_dict_metadata
                 assert_metadata(model_dict_metadata, other_metadata)
 
+    def test_export_model_dict_post_hooks(self):
+        """
+        Post hooks can return a modified model dict before it's written.
+        """
+        model = self._get_model()
+
+        calls = []
+
+        def rename_model(model_dict: dict) -> dict:
+            calls.append("rename_model")
+            assert model_dict["metadata"]["name"] == "Before hook"
+            return {
+                **model_dict,
+                "metadata": {
+                    **model_dict["metadata"],
+                    "name": "Renamed",
+                },
+                "hook_order": calls.copy(),
+            }
+
+        def replace_model_dict(model_dict: dict) -> dict:
+            calls.append("replace_model_dict")
+            assert model_dict["metadata"]["name"] == "Renamed"
+            return {
+                **model_dict,
+                "metadata": {
+                    **model_dict["metadata"],
+                    "name": "Replaced",
+                },
+                "hook_order": calls.copy(),
+                "config": {"hooked": True},
+            }
+
+        model.export_model_dict_post_hooks.append(rename_model)
+        model.export_model_dict_post_hooks.append(replace_model_dict)
+
+        with TemporaryDirectory() as tmpdir:
+            model.export(
+                tmpdir,
+                user_metadata=metadata.UserMetadata(name="Before hook"),
+            )
+            model_path = Path(tmpdir, "model.nam")
+            with open(model_path, "r") as fp:
+                model_dict = json.load(fp)
+
+        assert calls == ["rename_model", "replace_model_dict"]
+        assert model_dict["metadata"]["name"] == "Replaced"
+        assert model_dict["hook_order"] == calls
+        assert model_dict["config"] == {"hooked": True}
+
+    def test_export_model_dict_post_hooks_can_be_assigned(self):
+        """
+        Assigning a hook sequence replaces the hooks run at export time.
+        """
+        model = self._get_model()
+
+        def first_hook(model_dict: dict) -> dict:
+            return {**model_dict, "hooked": "first"}
+
+        def second_hook(model_dict: dict) -> dict:
+            return {**model_dict, "hooked": "second"}
+
+        model.export_model_dict_post_hooks = [first_hook]
+        model.export_model_dict_post_hooks = [second_hook]
+
+        with TemporaryDirectory() as tmpdir:
+            model.export(tmpdir)
+            model_path = Path(tmpdir, "model.nam")
+            with open(model_path, "r") as fp:
+                model_dict = json.load(fp)
+
+        assert model_dict["hooked"] == "second"
+
     @pytest.mark.parametrize("include_snapshot", (True, False))
     def test_include_snapshot(self, include_snapshot):
         """


### PR DESCRIPTION
Functionality that can be used e.g. by #662 to apply the changes to the head scale (as well as to fix the loudness metadata!)