### PR TITLE
Fix PackedWaveNet container_max_values sort check bypass

### DIFF
--- a/nam/models/wavenet/_packed_wavenet.py
+++ b/nam/models/wavenet/_packed_wavenet.py
@@ -214,9 +214,9 @@ class PackedWaveNet(_BaseNet, _ImportsWeights):
         if len(configured) != self.num_submodels:
             raise ValueError("container_max_values length must match submodels")
         values = [float(v) for v in configured]
-        values[-1] = 1.0
         if values != sorted(values):
             raise ValueError("container_max_values must be sorted")
+        values[-1] = 1.0
         return values
 
     def _normalize_checkpoint_paths(self, paths):

--- a/tests/test_nam/test_models/test_packed_wavenet.py
+++ b/tests/test_nam/test_models/test_packed_wavenet.py
@@ -209,6 +209,26 @@ def test_packed_extraction_matches_packed_output():
         assert _torch.allclose(extracted(x), y_packed[:, i, :], atol=1.0e-6)
 
 
+def test_packed_container_max_values_rejects_unsorted_before_last_coercion():
+    """Descending max_value lists must fail before values[-1] = 1.0 masks them."""
+    config = {
+        **_packed_config(),
+        "export": {"container_max_values": [1.0, 0.5]},
+    }
+    model = _PackedWaveNet.init_from_config(config)
+    with _pytest.raises(ValueError, match="container_max_values must be sorted"):
+        model._container_max_values()
+
+
+def test_packed_container_max_values_accepts_sorted_list():
+    config = {
+        **_packed_config(),
+        "export": {"container_max_values": [0.5, 0.75]},
+    }
+    model = _PackedWaveNet.init_from_config(config)
+    assert model._container_max_values() == [0.5, 1.0]
+
+
 def test_packed_export_writes_slimmable_container(tmp_path):
     model = _PackedWaveNet.init_from_config({**_packed_config(), "sample_rate": 48_000})
     container = model.export_container(tmp_path)


### PR DESCRIPTION
## Summary

Fixes a bug in `PackedWaveNet._container_max_values` where unsorted `export.container_max_values` lists could pass validation and export with wrong `max_value` metadata.

The sorted check ran **after** `values[-1] = 1.0`, so a descending list like `[1.0, 0.5]` was silently coerced to `[1.0, 1.0]` before comparison. Training/export could succeed while every submodel in the exported `SlimmableContainer` shared the same range — a misconfiguration that is easy to make if you order packs “best first.”

This PR validates sort order on the raw configured values first, then applies the intentional last-element coercion to `1.0`.

## Root cause

```python
values = [float(v) for v in configured]
values[-1] = 1.0                          # overwrote last element first
if values != sorted(values):              # sort check ran after coercion
    raise ValueError("container_max_values must be sorted")
```

For `configured = [1.0, 0.5]`:

1. `values = [1.0, 0.5]`
2. `values[-1] = 1.0` → `[1.0, 1.0]` (unsorted position masked)
3. Sort check passes; export assigns `max_value: 1.0` to all submodels

## Fix

```python
values = [float(v) for v in configured]
if values != sorted(values):
    raise ValueError("container_max_values must be sorted")
values[-1] = 1.0
return values
```

## Tests

- `test_packed_container_max_values_rejects_unsorted_before_last_coercion` — `[1.0, 0.5]` raises `ValueError`
- `test_packed_container_max_values_accepts_sorted_list` — `[0.5, 0.75]` still coerces last entry to `1.0` as before

## Test plan

- [x] `pytest tests/test_nam/test_models/test_packed_wavenet.py::test_packed_container_max_values_rejects_unsorted_before_last_coercion`
- [x] `pytest tests/test_nam/test_models/test_packed_wavenet.py::test_packed_container_max_values_accepts_sorted_list`
- [x] Full `tests/test_nam/test_models/test_packed_wavenet.py` (optional; no other behavior changed)