### PR TITLE
Log per-submodel MRSTFT metrics during packed validation

### DIFF
--- a/docs/source/tutorials/packed-training.rst
+++ b/docs/source/tutorials/packed-training.rst
@@ -151,8 +151,9 @@ During training, the packed model returns predictions shaped like
 ``(batch, submodel, time)``. The trainer computes the configured training loss
 for each submodel prediction against the same target audio and sums the losses.
 
-Validation logs aggregate metrics such as ``val_loss`` and ``ESR`` as well as
-per-submodel metrics such as ``val_loss_packed_0`` and ``ESR_packed_0``. When
+Validation logs aggregate metrics such as ``val_loss``, ``ESR``, and ``MRSTFT``
+as well as per-submodel metrics such as ``val_loss_packed_0``, ``ESR_packed_0``,
+and ``MRSTFT_packed_0``. When
 validation is available, the trainer may also save per-submodel best
 checkpoints named ``packed_best_submodel_<i>.ckpt``.
 

--- a/nam/train/lightning_module.py
+++ b/nam/train/lightning_module.py
@@ -513,9 +513,8 @@ class PackedLightningModule(LightningModule):
             val_loss = self._get_val_loss_from_loss_dict(loss_dict)
             val_losses.append(val_loss)
             logs[f"val_loss_packed_{i}"] = val_loss
-            logs[f"ESR_packed_{i}"] = loss_dict["ESR"].value
-            if "MSE" in loss_dict:
-                logs[f"MSE_packed_{i}"] = loss_dict["MSE"].value
+            for key, item in loss_dict.items():
+                logs[f"{key}_packed_{i}"] = item.value
 
         loss_keys = sorted({key for loss_dict in loss_dicts for key in loss_dict})
         for key in loss_keys:

--- a/tests/test_nam/test_train/test_lightning_module.py
+++ b/tests/test_nam/test_train/test_lightning_module.py
@@ -211,6 +211,27 @@ def test_packed_lightning_validation_logs_per_submodel_and_aggregate():
     )
 
 
+def test_packed_lightning_validation_logs_mrstft_per_submodel(mocker):
+    net = _packed_wavenet()
+    module = _lightning_module.PackedLightningModule(
+        net,
+        loss_config=_lightning_module.LossConfig(mrstft_weight=0.0002),
+    )
+    mocker.patch.object(
+        module,
+        "_mrstft_loss",
+        side_effect=[_torch.tensor(0.3), _torch.tensor(0.7)],
+    )
+    captured = {}
+    module.log_dict = lambda logs: captured.update(logs)
+    x = _torch.randn(3, net.receptive_field + 8)
+    targets = _torch.randn(3, x.shape[-1] - net.receptive_field + 1)
+    module.validation_step((x, targets), 0)
+    assert captured["MRSTFT_packed_0"] == 0.3
+    assert captured["MRSTFT_packed_1"] == 0.7
+    assert captured["MRSTFT"] == 1.0
+
+
 def test_packed_best_checkpoint_records_distinct_checkpoints(tmp_path):
     module = _lightning_module.PackedLightningModule(_packed_wavenet())
     callback = _lightning_module.PackedBestCheckpoint(dirpath=tmp_path)


### PR DESCRIPTION
## Summary
- Packed validation now logs per-submodel metrics for all loss keys (e.g. `MRSTFT_packed_0`, `MRSTFT_packed_1`), not only ESR/MSE
- Aggregate `MRSTFT` (sum across submodels) is unchanged
- No extra loss computation; only additional validation log keys

## Test plan
- [x] `pytest tests/test_nam/test_train/test_lightning_module.py::test_packed_lightning_validation_logs_per_submodel_and_aggregate`
- [x] `pytest tests/test_nam/test_train/test_lightning_module.py::test_packed_lightning_validation_logs_mrstft_per_submodel`