### PR TITLE
[BUGFIX] Fix version parsing crash when running from a dev checkout

### DIFF
--- a/nam/train/_version.py
+++ b/nam/train/_version.py
@@ -19,16 +19,14 @@ class Version:
 
     @classmethod
     def from_string(cls, s: str):
-        parts = s.split(".")
+        # Strip PEP 440 pre/dev/post suffixes (e.g. "0.1.dev344" -> "0.1")
+        s_clean = re.sub(r"(\.dev|\.post|a|b|rc)\d+.*$", "", s)
+        parts = s_clean.split(".")
+        parts += ["0"] * max(0, 3 - len(parts))
         try:
-            major, minor, patch = [
-                int(re.match(r"\d+", x).group()) if re.match(r"\d+", x) else 0
-                for x in parts[:3]
-            ]
+            major, minor, patch = [int(x) for x in parts[:3]]
         except ValueError as e:
-            raise ValueError(
-                f"Failed to parse version from string '{s}':\n{e}"
-            )
+            raise ValueError(f"Failed to parse version from string '{s}':\n{e}")
         return cls(major=major, minor=minor, patch=patch)
 
     def __eq__(self, other) -> bool:

--- a/nam/train/_version.py
+++ b/nam/train/_version.py
@@ -6,6 +6,8 @@
 Version utility
 """
 
+import re
+
 from .._version import __version__ as _package_version
 
 
@@ -19,9 +21,14 @@ class Version:
     def from_string(cls, s: str):
         parts = s.split(".")
         try:
-            major, minor, patch = [int(x) for x in parts[:3]]
+            major, minor, patch = [
+                int(re.match(r"\d+", x).group()) if re.match(r"\d+", x) else 0
+                for x in parts[:3]
+            ]
         except ValueError as e:
-            raise ValueError(f"Failed to parse version from string '{s}':\n{e}")
+            raise ValueError(
+                f"Failed to parse version from string '{s}':\n{e}"
+            )
         return cls(major=major, minor=minor, patch=patch)
 
     def __eq__(self, other) -> bool:


### PR DESCRIPTION
## Summary

`nam` crashes on launch when the package is installed in editable mode from source, because `setuptools-scm` generates version strings like `0.1.dev344` rather than clean semver like `0.12.3`. The version parser called `int()` directly on each component, which fails on strings like `dev344`.

### Before
<img width="644" height="581" alt="Screenshot 2026-05-24 at 6 13 47 PM" src="https://github.com/user-attachments/assets/8e5c2339-a855-4c95-b339-6b28d4d39bec" />

### After
<img width="875" height="611" alt="Screenshot 2026-05-24 at 6 13 01 PM" src="https://github.com/user-attachments/assets/3d847fc7-7628-45ad-b4fe-5119189bb789" />

## Fix

Strip PEP 440 pre/dev/post suffixes from the version string before parsing, then pad to 3 components if needed:

- `0.1.dev344` → `0.1` → `0.1.0`
- `0.12.3a1` → `0.12.3`
- `0.12.3rc1` → `0.12.3`

This approach keeps the original `int()` conversion path intact, so the `except ValueError` block continues to catch genuinely malformed version strings.

## Test plan

- [x] `nam` launches without error when installed with `pip install -e .`
- [x] All existing version comparisons (update check logic) continue to work correctly for release versions like `0.12.3`

🤖 Generated with [Claude Code](https://claude.ai/code)