### PR TITLE
[BUGFIX] Validate PackedWaveNet `container_max_values` before normalization

### DIFF
--- a/nam/models/wavenet/_packed_wavenet.py
+++ b/nam/models/wavenet/_packed_wavenet.py
@@ -214,6 +214,10 @@ class PackedWaveNet(_BaseNet, _ImportsWeights):
         if len(configured) != self.num_submodels:
             raise ValueError("container_max_values length must match submodels")
         values = [float(v) for v in configured]
+        if not all(0.0 <= v <= 1.0 for v in values):
+            raise ValueError("container_max_values must be in [0, 1]")
+        if len(values) != len(set(values)):
+            raise ValueError("container_max_values must not contain duplicates")
         if values != sorted(values):
             raise ValueError("container_max_values must be sorted")
         values[-1] = 1.0

--- a/nam/models/wavenet/_packed_wavenet.py
+++ b/nam/models/wavenet/_packed_wavenet.py
@@ -214,9 +214,9 @@ class PackedWaveNet(_BaseNet, _ImportsWeights):
         if len(configured) != self.num_submodels:
             raise ValueError("container_max_values length must match submodels")
         values = [float(v) for v in configured]
-        values[-1] = 1.0
         if values != sorted(values):
             raise ValueError("container_max_values must be sorted")
+        values[-1] = 1.0
         return values
 
     def _normalize_checkpoint_paths(self, paths):

--- a/tests/test_nam/test_models/test_packed_wavenet.py
+++ b/tests/test_nam/test_models/test_packed_wavenet.py
@@ -209,6 +209,26 @@ def test_packed_extraction_matches_packed_output():
         assert _torch.allclose(extracted(x), y_packed[:, i, :], atol=1.0e-6)
 
 
+def test_packed_container_max_values_rejects_unsorted_before_last_coercion():
+    """Descending max_value lists must fail before values[-1] = 1.0 masks them."""
+    config = {
+        **_packed_config(),
+        "export": {"container_max_values": [1.0, 0.5]},
+    }
+    model = _PackedWaveNet.init_from_config(config)
+    with _pytest.raises(ValueError, match="container_max_values must be sorted"):
+        model._container_max_values()
+
+
+def test_packed_container_max_values_accepts_sorted_list():
+    config = {
+        **_packed_config(),
+        "export": {"container_max_values": [0.5, 0.75]},
+    }
+    model = _PackedWaveNet.init_from_config(config)
+    assert model._container_max_values() == [0.5, 1.0]
+
+
 def test_packed_export_writes_slimmable_container(tmp_path):
     model = _PackedWaveNet.init_from_config({**_packed_config(), "sample_rate": 48_000})
     container = model.export_container(tmp_path)

--- a/tests/test_nam/test_models/test_packed_wavenet.py
+++ b/tests/test_nam/test_models/test_packed_wavenet.py
@@ -220,6 +220,26 @@ def test_packed_container_max_values_rejects_unsorted_before_last_coercion():
         model._container_max_values()
 
 
+def test_packed_container_max_values_rejects_values_outside_unit_interval():
+    config = {
+        **_packed_config(),
+        "export": {"container_max_values": [50.0, 100.0]},
+    }
+    model = _PackedWaveNet.init_from_config(config)
+    with _pytest.raises(ValueError, match=r"container_max_values must be in \[0, 1\]"):
+        model._container_max_values()
+
+
+def test_packed_container_max_values_rejects_duplicate_values():
+    config = {
+        **_packed_config(),
+        "export": {"container_max_values": [0.5, 0.5]},
+    }
+    model = _PackedWaveNet.init_from_config(config)
+    with _pytest.raises(ValueError, match="container_max_values must not contain duplicates"):
+        model._container_max_values()
+
+
 def test_packed_container_max_values_accepts_sorted_list():
     config = {
         **_packed_config(),


### PR DESCRIPTION
Continues #667 by adding a few more validations.

* Validate custom container_max_values before coercing the final value to 1.0.
* Reject values outside [0, 1], including [50.0, 100.0].
* Reject duplicate values so accepted lists are strictly monotonically increasing.
* Preserve existing behavior where a valid final value less than 1.0 is normalized to 1.0 for export.