### PR TITLE
Abstract Lightning module class inference to utility function

### DIFF
--- a/nam/train/full.py
+++ b/nam/train/full.py
@@ -25,6 +25,7 @@ from nam.data import apply_joint_dataset_hooks as _apply_joint_dataset_hooks
 from nam.data import get_joint_dataset_hooks as _get_joint_dataset_hooks
 from nam.data import init_dataset as _init_dataset
 from nam.train import lightning_module as _lightning_module
+from nam.train import util as _util
 from nam.util import filter_warnings as _filter_warnings
 
 _torch.manual_seed(0)
@@ -208,11 +209,7 @@ def main(
             _json.dump(config, fp, indent=4)
 
     is_packed = model_config["net"]["name"] == "PackedWaveNet"
-    lightning_cls = (
-        _lightning_module.PackedLightningModule
-        if is_packed
-        else _lightning_module.LightningModule
-    )
+    lightning_cls = _util.resolve_lightning_module_class(model_config)
     model = lightning_cls.init_from_config(model_config)
     # Add receptive field to data config:
     data_config["common"] = data_config.get("common", {})

--- a/nam/train/util.py
+++ b/nam/train/util.py
@@ -1,0 +1,15 @@
+from typing import Any as _Any
+from typing import Mapping as _Mapping
+from typing import Type as _Type
+
+from nam.train import lightning_module as _lightning_module
+
+
+def resolve_lightning_module_class(
+    model_config: _Mapping[str, _Any],
+) -> _Type[_lightning_module.LightningModule]:
+    return (
+        _lightning_module.PackedLightningModule
+        if model_config["net"]["name"] == "PackedWaveNet"
+        else _lightning_module.LightningModule
+    )

--- a/tests/test_nam/test_train/test_util.py
+++ b/tests/test_nam/test_train/test_util.py
@@ -1,0 +1,18 @@
+import pytest
+
+from nam.train import lightning_module as _lightning_module
+from nam.train import util as _util
+
+
+@pytest.mark.parametrize(
+    ("net_name", "expected"),
+    (
+        ("PackedWaveNet", _lightning_module.PackedLightningModule),
+        ("WaveNet", _lightning_module.LightningModule),
+        ("LSTM", _lightning_module.LightningModule),
+    ),
+)
+def test_resolve_lightning_module_class(net_name, expected):
+    model_config = {"net": {"name": net_name}}
+
+    assert _util.resolve_lightning_module_class(model_config) is expected


### PR DESCRIPTION
## Summary
- add `resolve_lightning_module_class(model_config)` in `nam.train.util`
- use the resolver from `nam-full` instead of selecting the Lightning module class inline
- cover packed and standard model configurations with focused unit tests

## Tests
- `python -m pytest tests/test_nam/test_train/test_util.py tests/test_nam/test_train/test_full_packed.py -q` (4 passed)
- `python -m pytest -q --ignore=tests/test_graceful_shutdown.py --ignore=tests/test_bin` (372 passed, 21 skipped)
- `python -m black --check nam/train/util.py nam/train/full.py tests/test_nam/test_train/test_util.py`
- `python -m flake8 nam/train/util.py nam/train/full.py tests/test_nam/test_train/test_util.py --count --select=E9,F63,F7,F82 --show-source --statistics`

The full unfiltered suite cannot run from this worktree because CLI subprocess tests invoke the globally installed `nam-full`, whose editable installation points to a different checkout.

Resolves #684
