### PR TITLE
ci: test against Python 3.14

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add Python 3.14 to the GitHub Actions test matrix
- retain the existing Python 3.10-3.13 coverage

## Validation
- `git diff --check`
- verified Python 3.14.6 availability with `uv run --python 3.14 --no-project python --version`

Fixes sdatkinson/neural-amp-modeler#686

Contributed by @ANONYMOUSZED-beep.
