### PR TITLE
Fix delay calibration tests on Python 3.14

### DIFF
--- a/tests/test_nam/test_train/test_core.py
+++ b/tests/test_nam/test_train/test_core.py
@@ -229,22 +229,23 @@ class _TCalibrateDelay(object):
 
 
 class TestCalibrateDelayV1(_TCalibrateDelay):
-    _calibrate_delay = core._calibrate_latency_v1
+    # functools.partial is a method descriptor in Python 3.14.
+    _calibrate_delay = staticmethod(core._calibrate_latency_v1)
     _data_info = core._V1_DATA_INFO
 
 
 class TestCalibrateDelayV2(_TCalibrateDelay):
-    _calibrate_delay = core._calibrate_latency_v2
+    _calibrate_delay = staticmethod(core._calibrate_latency_v2)
     _data_info = core._V2_DATA_INFO
 
 
 class TestCalibrateDelayV3(_TCalibrateDelay):
-    _calibrate_delay = core._calibrate_latency_v3
+    _calibrate_delay = staticmethod(core._calibrate_latency_v3)
     _data_info = core._V3_DATA_INFO
 
 
 class TestCalibrateDelayV4(_TCalibrateDelay):
-    _calibrate_delay = core._calibrate_latency_v4
+    _calibrate_delay = staticmethod(core._calibrate_latency_v4)
     _data_info = core._V4_DATA_INFO
 
 


### PR DESCRIPTION
## Summary
- preserve the delay-calibration tests' existing calling convention on Python 3.14
- wrap `functools.partial` class attributes with `staticmethod` so instances do not bind an extra `self` argument
- keep the same behavior on Python 3.10 through 3.13

## Tests
- `python -m pytest -q tests/test_nam/test_train/test_core.py` (27 passed, 15 skipped)
- `python -m pytest -q tests/test_nam/test_train/test_core.py -k 'TestCalibrateDelay'` (20 passed)
- `python -m flake8 tests/test_nam/test_train/test_core.py --count --select=E9,F63,F7,F82 --show-source --statistics`

The Python 3.14 CI matrix job provides the final cross-version verification because Python 3.14 is not installed in the local development environment.
