### PR TITLE
Fix Sequential model serialization format

### DIFF
--- a/docs/source/model-file.rst
+++ b/docs/source/model-file.rst
@@ -57,6 +57,36 @@ There are also some optional keys that ``nam`` may use:
     modeled.
 
 
+Sequential models
+-----------------
+
+``"Sequential"`` models compose complete child NAM models in processing order.
+They use the existing file version and top-level envelope. The wrapper has an
+empty ``"weights"`` array because its parameters belong to its children::
+
+  {
+    "version": "0.7.0",
+    "architecture": "Sequential",
+    "config": {
+      "models": [
+        {"version": "0.7.0", "architecture": "WaveNet", "config": {}, "weights": [], "sample_rate": 48000},
+        {"version": "0.7.0", "architecture": "Linear", "config": {}, "weights": [], "sample_rate": 48000}
+      ]
+    },
+    "weights": [],
+    "sample_rate": 48000
+  }
+
+Every entry in ``config.models`` is a complete NAM model with its own
+architecture, configuration, and weights. The top-level and child sample rates
+must agree.
+
+Sequential files exported before Core support was completed used bare child
+configs and concatenated top-level weights. Because those files omitted the
+child architectures, they cannot be interpreted reliably and are not supported
+by this canonical format.
+
+
 Change log
 ----------
 

--- a/nam/models/_from_nam.py
+++ b/nam/models/_from_nam.py
@@ -180,7 +180,6 @@ def init_from_nam(config) -> _BaseNet:
         "WaveNet": _init_wavenet,
         "LSTM": _init_lstm,
         "Sequential": _init_sequential,
-        "sequential": _init_sequential,
     }[config["architecture"]](
         config=config["config"], sample_rate=config.get("sample_rate", None)
     )

--- a/nam/models/_from_nam.py
+++ b/nam/models/_from_nam.py
@@ -17,6 +17,7 @@ import torch as _torch
 from .base import BaseNet as _BaseNet
 from .linear import Linear as _Linear
 from .recurrent import LSTM as _LSTM
+from .sequential import Sequential as _Sequential
 from .wavenet import WaveNet as _WaveNet
 
 
@@ -143,6 +144,27 @@ def _init_wavenet(config, sample_rate: _Optional[float]) -> _WaveNet:
     return _WaveNet.init_from_config(full_config)
 
 
+def _init_sequential(config, sample_rate: _Optional[float]) -> _Sequential:
+    models = config.get("models")
+    if not isinstance(models, list) or len(models) == 0:
+        raise ValueError("Sequential config must contain a non-empty 'models' list")
+
+    required_keys = {"version", "architecture", "config", "weights"}
+    for model in models:
+        if not isinstance(model, dict) or not required_keys.issubset(model):
+            raise ValueError(
+                "Sequential children must be complete NAM model objects with version, "
+                "architecture, config, and weights"
+            )
+
+    sequential = _Sequential(models=[init_from_nam(model) for model in models])
+    if sample_rate is not None and sequential.sample_rate != sample_rate:
+        raise ValueError(
+            "Sequential top-level sample rate does not match its child model sample rate"
+        )
+    return sequential
+
+
 def init_from_nam(config) -> _BaseNet:
     """
     Taking the contents of a .nam file, initialize a model
@@ -153,8 +175,14 @@ def init_from_nam(config) -> _BaseNet:
     ...     model = init_from_nam(config)
     """
     # NB: Some old .nam files don't have a sample_rate. Must .get()
-    model = {"Linear": _init_linear, "WaveNet": _init_wavenet, "LSTM": _init_lstm}[
-        config["architecture"]
-    ](config=config["config"], sample_rate=config.get("sample_rate", None))
+    model = {
+        "Linear": _init_linear,
+        "WaveNet": _init_wavenet,
+        "LSTM": _init_lstm,
+        "Sequential": _init_sequential,
+        "sequential": _init_sequential,
+    }[config["architecture"]](
+        config=config["config"], sample_rate=config.get("sample_rate", None)
+    )
     model.import_weights(_torch.Tensor(config["weights"]))
     return model

--- a/nam/models/sequential.py
+++ b/nam/models/sequential.py
@@ -50,14 +50,17 @@ class Sequential(_BaseNet):
 
     def _export_config(self):
         """Export configuration for the sequential model."""
-        return {"models": [model._export_config() for model in self._models]}
+        return {"models": [model._get_export_dict() for model in self._models]}
 
     def _export_weights(self):
-        """Export weights for the sequential model."""
-        weights_list = []
-        for model in self._models:
-            weights_list.append(model._export_weights())
-        return _np.concatenate(weights_list)
+        """The wrapper has no weights; each complete child model owns its weights."""
+        return _np.array([], dtype=_np.float32)
+
+    def import_weights(self, weights):
+        if len(weights) != 0:
+            raise ValueError(
+                "Sequential top-level weights must be empty; weights belong to the child models"
+            )
 
     @classmethod
     def _validate_models(cls, models: _Sequence[_BaseNet]):

--- a/tests/test_nam/test_models/test_sequential.py
+++ b/tests/test_nam/test_models/test_sequential.py
@@ -286,6 +286,16 @@ class TestSequential(_Base):
         with _pytest.raises(ValueError, match="top-level weights"):
             _from_nam.init_from_nam(exported)
 
+    def test_init_from_nam_rejects_lowercase_architecture(self):
+        sample_rate = 48_000
+        exported = _sequential.Sequential(
+            models=[_linear.Linear(receptive_field=1, sample_rate=sample_rate)]
+        )._get_export_dict()
+        exported["architecture"] = "sequential"
+
+        with _pytest.raises(KeyError, match="sequential"):
+            _from_nam.init_from_nam(exported)
+
     def test_receptive_field(self):
         """Test some receptive field arithmetic"""
         # Create models with larger receptive fields
@@ -319,17 +329,17 @@ class TestSequential(_Base):
         assert y.shape[0] == 3  # Batch dimension preserved
         assert y.shape[1] == x.shape[1] - seq_model.receptive_field + 1
 
-    def test_export_weights_uses_chronological_linear_taps(self):
+    def test_exported_child_weights_use_chronological_linear_taps(self):
         linear1 = _linear.Linear(receptive_field=3)
         linear1._net.weight.data.copy_(_torch.tensor([[[1.0, 2.0, 3.0]]]))
         linear2 = _linear.Linear(receptive_field=1)
         linear2._net.weight.data.copy_(_torch.tensor([[[4.0]]]))
         model = _sequential.Sequential(models=[linear1, linear2])
 
-        _torch.testing.assert_close(
-            _torch.from_numpy(model._export_weights()),
-            _torch.tensor([3.0, 2.0, 1.0, 4.0]),
-        )
+        children = model._get_export_dict()["config"]["models"]
+
+        assert children[0]["weights"] == [3.0, 2.0, 1.0]
+        assert children[1]["weights"] == [4.0]
 
 
 if __name__ == "__main__":

--- a/tests/test_nam/test_models/test_sequential.py
+++ b/tests/test_nam/test_models/test_sequential.py
@@ -6,6 +6,7 @@ import pytest as _pytest
 import torch as _torch
 
 from nam.models import conv_net as _conv_net
+from nam.models import _from_nam as _from_nam
 from nam.models import linear as _linear
 from nam.models import sequential as _sequential
 
@@ -198,6 +199,92 @@ class TestSequential(_Base):
         assert all(
             isinstance(model, _linear.Linear) for model in parsed_config["models"]
         )
+
+    def test_export_uses_canonical_container_envelope(self):
+        sample_rate = 48_000
+        models = [
+            _linear.Linear(receptive_field=2, sample_rate=sample_rate),
+            _linear.Linear(receptive_field=3, sample_rate=sample_rate),
+        ]
+        model = _sequential.Sequential(models=models)
+
+        exported = model._get_export_dict()
+
+        assert exported["version"] == "0.7.0"
+        assert exported["architecture"] == "Sequential"
+        assert exported["weights"] == []
+        assert exported["sample_rate"] == sample_rate
+        assert "weights_version" not in exported["config"]
+        children = exported["config"]["models"]
+        assert [child["architecture"] for child in children] == ["Linear", "Linear"]
+        assert [child["sample_rate"] for child in children] == [
+            sample_rate,
+            sample_rate,
+        ]
+        assert [len(child["weights"]) for child in children] == [2, 3]
+
+    def test_init_from_nam_roundtrip(self):
+        sample_rate = 48_000
+        model = _sequential.Sequential(
+            models=[
+                _linear.Linear(receptive_field=2, sample_rate=sample_rate),
+                _linear.Linear(receptive_field=3, sample_rate=sample_rate),
+            ]
+        )
+        exported = model._get_export_dict()
+
+        restored = _from_nam.init_from_nam(exported)
+
+        assert isinstance(restored, _sequential.Sequential)
+        x = _torch.randn(256)
+        _torch.testing.assert_close(
+            restored(x, pad_start=False), model(x, pad_start=False)
+        )
+
+    def test_init_from_nam_roundtrip_nested(self):
+        sample_rate = 48_000
+        inner = _sequential.Sequential(
+            models=[
+                _linear.Linear(receptive_field=1, sample_rate=sample_rate),
+                _linear.Linear(receptive_field=1, sample_rate=sample_rate),
+            ]
+        )
+        model = _sequential.Sequential(
+            models=[inner, _linear.Linear(receptive_field=1, sample_rate=sample_rate)]
+        )
+
+        restored = _from_nam.init_from_nam(model._get_export_dict())
+
+        assert isinstance(restored, _sequential.Sequential)
+        assert isinstance(restored._models[0], _sequential.Sequential)
+        x = _torch.randn(64)
+        _torch.testing.assert_close(restored(x), model(x))
+
+    def test_init_from_nam_rejects_legacy_bare_child_configs(self):
+        sample_rate = 48_000
+        exported = _sequential.Sequential(
+            models=[
+                _linear.Linear(receptive_field=1, sample_rate=sample_rate),
+                _linear.Linear(receptive_field=1, sample_rate=sample_rate),
+            ]
+        )._get_export_dict()
+        exported["config"]["models"] = [
+            {"receptive_field": 1, "bias": False},
+            {"receptive_field": 1, "bias": False},
+        ]
+
+        with _pytest.raises(ValueError, match="complete NAM model"):
+            _from_nam.init_from_nam(exported)
+
+    def test_init_from_nam_rejects_nonempty_top_level_weights(self):
+        sample_rate = 48_000
+        exported = _sequential.Sequential(
+            models=[_linear.Linear(receptive_field=1, sample_rate=sample_rate)]
+        )._get_export_dict()
+        exported["weights"] = [1.0]
+
+        with _pytest.raises(ValueError, match="top-level weights"):
+            _from_nam.init_from_nam(exported)
 
     def test_receptive_field(self):
         """Test some receptive field arithmetic"""


### PR DESCRIPTION
## Summary
- serialize `Sequential` as a true container whose `config.models` entries are complete child NAM objects
- keep the wrapper's top-level `weights` empty so each child owns its architecture, configuration, weights, and sample rate
- add recursive import support for canonical and nested Sequential models
- require the case-sensitive architecture name `"Sequential"`
- reject non-empty wrapper weights and the unrecoverable legacy bare-child-config representation
- document the intentional compatibility break without changing the `.nam` file version

This aligns trainer exports with the Sequential support merged in NeuralAmpModelerCore#323 and supersedes the experimental serialization introduced in #596.

The branch is based on the current `main`, including the Linear tap-order fix from #697. Its chronological-tap test now verifies the weights inside each exported child rather than the removed flattened wrapper weights.

## Tests
- `python -m pytest -q tests/test_nam/test_models/test_sequential.py tests/test_nam/test_models/test_from_nam.py tests/test_nam/test_models/test_factory.py` — 48 passed, 1 skipped
- `python -m pytest -q --ignore=tests/test_graceful_shutdown.py --ignore=tests/test_bin` — 382 passed, 21 skipped
- `python -m black --check nam/models/_from_nam.py nam/models/sequential.py tests/test_nam/test_models/test_sequential.py`
- `python -m sphinx -W -b html docs/source build/docs-html`

## Compatibility note
Earlier experimental Sequential files stored bare child configs plus flattened top-level weights. Those files cannot be reconstructed reliably because they omit child architectures and weight boundaries, so this PR intentionally rejects them while retaining file version `0.7.0`.
